### PR TITLE
fix: editConfig parse 函数 showTitle 判空逻辑错误修复

### DIFF
--- a/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
+++ b/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
@@ -86,7 +86,7 @@ const PropertyConfig = () => {
           formData.title = Object.assign({}, uiSchema.title, {
             title: dataSchema?.title || '',
             followRootConfig: isEmpty(uiSchema.title),
-            // showTitle: uiSchema?.showTitle || true,
+            showTitle: uiSchema?.showTitle ?? true,
           })
         }
         if (key === 'footer') {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
editConfig parse 函数 showTitle 判空逻辑错误修复
(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?
yes
(Write your answer here.)

## Test Plan
![image](https://user-images.githubusercontent.com/36527485/147431389-f4d34863-71c6-48d7-b912-847e8e969b15.png)

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs
[Bug] 组件是否展示标题选择不展示，再次进入组件标题配置时，展示仍然被勾选 #68
(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/JDFED/drip-form/tree/dev/website, and link to your PR here.)
