### PR TITLE
fix: 时间选择器，默认占位符文案保持一致

### DIFF
--- a/packages/generator/src/fields/formItem/datepicker.field.ts
+++ b/packages/generator/src/fields/formItem/datepicker.field.ts
@@ -67,7 +67,7 @@ const config: Field = {
         title: '占位符',
         ui: {
           type: 'text',
-          placeholder: '请选择时间',
+          placeholder: '请选择日期',
           vcontrol: 'return !props.formData.ui.range',
         },
       },

--- a/packages/generator/src/fields/formItem/timepicker.field.ts
+++ b/packages/generator/src/fields/formItem/timepicker.field.ts
@@ -74,9 +74,9 @@ const config: Field = {
         fieldKey: 'placeholder',
         type: 'string',
         title: '占位符',
-        default: '请选择时间',
         ui: {
           type: 'text',
+          placeholder: '请选择时间',
           vcontrol: 'return !props.formData.ui.range',
         },
       },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
时间选择器，默认占位符文案保持一致
(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?
yes
(Write your answer here.)

## Test Plan
![image](https://user-images.githubusercontent.com/36527485/148386224-caf67c76-20a3-4972-94f1-38b363bd14e1.png)

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs
[Bug] 日期选择器，默认占位符文案不匹配 #95
(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/JDFED/drip-form/tree/dev/website, and link to your PR here.)
