### PR TITLE
feat: ajv format添加https校验

### DIFF
--- a/packages/drip-form-plugin-formats/__tests__/index.ts
+++ b/packages/drip-form-plugin-formats/__tests__/index.ts
@@ -23,6 +23,17 @@ describe('addFormats', () => {
     })
   })
 
+  test('https', () => {
+    addFormats(ajv)
+    const validate = ajv.compile({ type: 'string', format: 'https' })
+    expect(
+      validate('https://www.example.com/foo/?bar=baz&inga=42&quux')
+    ).toEqual(true)
+    expect(validate('https://www.example.com')).toEqual(true)
+    expect(validate('http://www.example.com')).toEqual(false)
+    expect(validate('//www.example.com')).toEqual(false)
+  })
+
   test('color', () => {
     addFormats(ajv)
     const validate = ajv.compile({ type: 'string', format: 'color' })

--- a/packages/drip-form-plugin-formats/src/formats/https.ts
+++ b/packages/drip-form-plugin-formats/src/formats/https.ts
@@ -1,0 +1,12 @@
+/*
+ * 校验https格式url
+ * For test cases: https://mathiasbynens.be/demo/url-regex
+ * @Author: jiangxiaowei
+ * @Date: 2022-01-07 17:44:59
+ * @Last Modified by: jiangxiaowei
+ * @Last Modified time: 2022-01-07 17:46:47
+ */
+
+const https =
+  /^(https):\/\/(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u{00a1}-\u{ffff}]+-)*[a-z0-9\u{00a1}-\u{ffff}]+)(?:\.(?:[a-z0-9\u{00a1}-\u{ffff}]+-)*[a-z0-9\u{00a1}-\u{ffff}]+)*(?:\.(?:[a-z\u{00a1}-\u{ffff}]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?$/iu
+export default https

--- a/packages/drip-form-plugin-formats/src/formats/index.ts
+++ b/packages/drip-form-plugin-formats/src/formats/index.ts
@@ -1,9 +1,11 @@
 import color from './color'
 import dateTime from './dateTime'
+import https from './https'
 
 export type formatsName = 'date-time' | 'color'
 
 export default {
   'date-time': dateTime,
-  color: color,
+  color,
+  https,
 }

--- a/packages/drip-form-plugin-formats/src/index.ts
+++ b/packages/drip-form-plugin-formats/src/index.ts
@@ -4,13 +4,13 @@
  * @Author: jiangxiaowei
  * @Date: 2021-07-29 12:56:28
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2021-08-17 15:45:43
+ * @Last Modified time: 2022-01-07 17:48:50
  */
 import formats from './formats'
 import type { formatsName } from './formats'
-import type { Plugin, Options } from 'ajv/dist/2019'
+import type { Plugin } from 'ajv/dist/2019'
 
-const addFormat: Plugin<Options> = (ajv, options) => {
+const addFormat: Plugin<Array<formatsName>> = (ajv, options) => {
   if (Array.isArray(options)) {
     Object.keys(formats)
       .filter((item) => options.includes(item as formatsName))

--- a/packages/generator/src/fields/common/checkConfig/String/index.ts
+++ b/packages/generator/src/fields/common/checkConfig/String/index.ts
@@ -3,7 +3,7 @@
  * @Author: jiangxiaowei
  * @Date: 2021-08-16 11:31:04
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2021-08-31 14:00:15
+ * @Last Modified time: 2022-01-07 17:52:48
  */
 // dataSchema2019-09支持的字符串校验关键字
 const stringJsonSchema = {
@@ -49,6 +49,11 @@ const stringJsonSchema = {
         {
           value: 'color',
           label: 'color',
+        },
+        // 水滴官方format插件 https关键字
+        {
+          value: 'https',
+          label: 'https',
         },
         {
           value: 'date',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

ajv string校验format添加https校验

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

```
  test('https', () => {
    addFormats(ajv)
    const validate = ajv.compile({ type: 'string', format: 'https' })
    expect(
      validate('https://www.example.com/foo/?bar=baz&inga=42&quux')
    ).toEqual(true)
    expect(validate('https://www.example.com')).toEqual(true)
    expect(validate('http://www.example.com')).toEqual(false)
    expect(validate('//www.example.com')).toEqual(false)
  })
```

## Related PRs

N