### PR TITLE
fix: 日期选择器和时间选择器，开启范围，可配置placeholder 和 默认值

### DIFF
--- a/packages/drip-form-theme-antd/src/DatePickerField/index.tsx
+++ b/packages/drip-form-theme-antd/src/DatePickerField/index.tsx
@@ -40,6 +40,10 @@ const DatePickerField = ({
   asyncValidate,
   showTime,
   getKey,
+  placeholder__range = {
+    0: '请选择日期',
+    1: '请选择日期',
+  },
   ...restProps
 }: DatePickerFieldProps) => {
   /**
@@ -108,6 +112,10 @@ const DatePickerField = ({
             }
           : showTime
       }
+      placeholder={[
+        placeholder__range[0] ?? '请选择日期',
+        placeholder__range[1] ?? '请选择日期',
+      ]}
       {...restProps}
     />
   ) : (

--- a/packages/drip-form-theme-antd/src/TimePickerField/index.tsx
+++ b/packages/drip-form-theme-antd/src/TimePickerField/index.tsx
@@ -35,6 +35,10 @@ const TimePickerField: FC<TimePickerFieldProps> = ({
   asyncValidate,
   format = 'HH:mm:ss',
   getKey,
+  placeholder__range = {
+    0: '请选择时间',
+    1: '请选择时间',
+  },
   ...restProps
 }) => {
   /**
@@ -93,6 +97,10 @@ const TimePickerField: FC<TimePickerFieldProps> = ({
       use12Hours={use12Hours}
       format={format}
       locale={locale}
+      placeholder={[
+        placeholder__range[0] ?? '请选择时间',
+        placeholder__range[1] ?? '请选择时间',
+      ]}
       {...restProps}
     />
   ) : (

--- a/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
+++ b/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
@@ -98,6 +98,18 @@ const PropertyConfig = () => {
             // onCancel:
           })
         }
+        // 时间｜日期 开启范围选择器，要将default数组类型转换为default__range对象类型
+        if (
+          key === 'ui' &&
+          (formData.ui.type === 'timePicker' ||
+            formData.ui.type === 'datePicker') &&
+          formData.ui.range
+        ) {
+          formData.ui.default__range = {}
+          formData.ui.default.forEach((item: string, index: number) => {
+            formData.ui.default__range[index] = item
+          })
+        }
       })
       return formData
     },
@@ -203,6 +215,7 @@ const PropertyConfig = () => {
           data = get('ui.default__range').data
         }
       }
+      // 时间｜日期 开启范围选择器，要将default__range对象类型转换为default数组类型
       if (type === 'timePicker' || type === 'datePicker') {
         if (changeKey === 'ui.range') {
           setFormData = true

--- a/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
+++ b/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
@@ -198,6 +198,20 @@ const PropertyConfig = () => {
         changeSchema = 'dataSchema'
         // 在ajv校验时，如果formData中已经有值，则不再生成新的formData，需要set formData
         setFormData = true
+        if (changeKey.includes('ui.default__range')) {
+          key = 'ui.default'
+          data = get('ui.default__range').data
+        }
+      }
+      if (type === 'timePicker' || type === 'datePicker') {
+        if (changeKey === 'ui.range') {
+          setFormData = true
+          if (data === true) {
+            fieldData = get('ui.default__range').data
+          } else {
+            fieldData = get('ui.default').data
+          }
+        }
       }
       // 填充渲染区Schema
       generatorContext.current?.set(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
日期选择器和时间选择器，开启范围，可配置placeholder
(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?
y
(Write your answer here.)

## Test Plan
![image](https://user-images.githubusercontent.com/36527485/148768079-4e33f824-057b-4c76-84f9-16609ce3b69c.png)

![image](https://user-images.githubusercontent.com/36527485/148773762-c8917380-1725-44c8-bea5-cd5c821e60e8.png)


(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs
[Bug] 日期选择器，开启范围，占位符填写不生效 #97
(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/JDFED/drip-form/tree/dev/website, and link to your PR here.)
