### PR TITLE
fix: 日期选择器和时间选择器，开启范围，支持设置默认值和placeholder

### DIFF
--- a/packages/drip-form-theme-antd/src/DatePickerField/index.tsx
+++ b/packages/drip-form-theme-antd/src/DatePickerField/index.tsx
@@ -40,6 +40,10 @@ const DatePickerField = ({
   asyncValidate,
   showTime,
   getKey,
+  placeholder__range = {
+    0: '请选择日期',
+    1: '请选择日期',
+  },
   ...restProps
 }: DatePickerFieldProps) => {
   /**
@@ -65,13 +69,13 @@ const DatePickerField = ({
   useEffect(() => {
     try {
       // 点击清空的时候，会变成null。
-      if (fieldData === null || fieldData === '') {
+      if (fieldData === null || fieldData === undefined || fieldData === '') {
         setValid(true)
       } else {
         if (range) {
           setValid(
-            moment(fieldData[0], format).isValid() &&
-              moment(fieldData[1], format).isValid()
+            (!fieldData[0] || moment(fieldData[0], format).isValid()) &&
+              (!fieldData[1] || moment(fieldData[1], format).isValid())
           )
         } else {
           setValid(moment(fieldData, format).isValid())
@@ -90,8 +94,11 @@ const DatePickerField = ({
       {...(isValid
         ? {
             value: fieldData
-              ? [moment(fieldData[0], format), moment(fieldData[1], format)]
-              : undefined,
+              ? [
+                  fieldData[0] ? moment(fieldData[0], format) : null,
+                  fieldData[1] ? moment(fieldData[1], format) : null,
+                ]
+              : null,
           }
         : null)}
       onChange={_onChange}
@@ -108,6 +115,10 @@ const DatePickerField = ({
             }
           : showTime
       }
+      placeholder={[
+        placeholder__range[0] ?? '请选择日期',
+        placeholder__range[1] ?? '请选择日期',
+      ]}
       {...restProps}
     />
   ) : (

--- a/packages/drip-form-theme-antd/src/TimePickerField/index.tsx
+++ b/packages/drip-form-theme-antd/src/TimePickerField/index.tsx
@@ -35,6 +35,10 @@ const TimePickerField: FC<TimePickerFieldProps> = ({
   asyncValidate,
   format = 'HH:mm:ss',
   getKey,
+  placeholder__range = {
+    0: '请选择时间',
+    1: '请选择时间',
+  },
   ...restProps
 }) => {
   /**
@@ -60,13 +64,13 @@ const TimePickerField: FC<TimePickerFieldProps> = ({
   useEffect(() => {
     try {
       // 点击清空的时候，会变成null。
-      if (fieldData === null) {
+      if (fieldData === null || fieldData === undefined || fieldData === '') {
         setValid(true)
       } else {
         if (range) {
           setValid(
-            moment(fieldData[0], 'HH:mm:ss').isValid() &&
-              moment(fieldData[1], 'HH:mm:ss').isValid()
+            (!fieldData[0] || moment(fieldData[0], 'HH:mm:ss').isValid()) &&
+              (!fieldData[1] || moment(fieldData[1], 'HH:mm:ss').isValid())
           )
         } else {
           setValid(moment(fieldData, 'HH:mm:ss').isValid())
@@ -77,14 +81,15 @@ const TimePickerField: FC<TimePickerFieldProps> = ({
       setValid(false)
     }
   }, [fieldData, range])
+
   return range ? (
     <RangePicker
       {...(isValid
         ? {
             value: fieldData
               ? [
-                  moment(fieldData[0], 'HH:mm:ss'),
-                  moment(fieldData[1], 'HH:mm:ss'),
+                  fieldData[0] ? moment(fieldData[0], 'HH:mm:ss') : null,
+                  fieldData[1] ? moment(fieldData[1], 'HH:mm:ss') : null,
                 ]
               : null,
           }
@@ -93,6 +98,10 @@ const TimePickerField: FC<TimePickerFieldProps> = ({
       use12Hours={use12Hours}
       format={format}
       locale={locale}
+      placeholder={[
+        placeholder__range[0] ?? '请选择时间',
+        placeholder__range[1] ?? '请选择时间',
+      ]}
       {...restProps}
     />
   ) : (

--- a/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
+++ b/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
@@ -98,6 +98,15 @@ const PropertyConfig = () => {
             // onCancel:
           })
         }
+        // 时间｜日期 开启范围选择器，default__range的值要从default中获取
+        if (
+          key === 'ui' &&
+          (formData.ui.type === 'timePicker' ||
+            formData.ui.type === 'datePicker') &&
+          formData.ui.range
+        ) {
+          formData.ui.default__range = formData.ui.default || []
+        }
       })
       return formData
     },
@@ -198,6 +207,22 @@ const PropertyConfig = () => {
         changeSchema = 'dataSchema'
         // 在ajv校验时，如果formData中已经有值，则不再生成新的formData，需要set formData
         setFormData = true
+        // 如果是范围选择器，需要从default__range取值
+        if (changeKey.includes('ui.default__range')) {
+          key = 'ui.default'
+          data = get('ui.default__range').data
+        }
+      }
+      // 时间｜日期 切换范围选择器时，fieldData需要分别从不同字段取值
+      if (type === 'timePicker' || type === 'datePicker') {
+        if (changeKey === 'ui.range') {
+          setFormData = true
+          if (data === true) {
+            fieldData = get('ui.default__range').data
+          } else {
+            fieldData = get('ui.default').data
+          }
+        }
       }
       // 填充渲染区Schema
       generatorContext.current?.set(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
日期选择器和时间选择器，开启范围，支持设置默认值和placeholder
(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?
y
(Write your answer here.)

## Test Plan
![image](https://user-images.githubusercontent.com/36527485/148876377-80b5b1e6-b912-48de-b8a1-d3077c4b2f2e.png)

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/JDFED/drip-form/tree/dev/website, and link to your PR here.)
