### PR TITLE
feat: ajv keyword添加gbkLength关键字

### DIFF
--- a/packages/drip-form-plugin-keywords/__tests__/index.test.ts
+++ b/packages/drip-form-plugin-keywords/__tests__/index.test.ts
@@ -23,6 +23,30 @@ describe('addKeywords', () => {
     })
   })
 
+  test('gbkLength', () => {
+    addKeywords(ajv)
+    const validate = ajv.compile({
+      type: 'string',
+      gbkLength: {
+        max: 4,
+        min: 1,
+      },
+    })
+    expect(validate('')).toEqual(false)
+    expect(validate('a')).toEqual(true)
+    expect(validate('ab')).toEqual(true)
+    expect(validate('abcd')).toEqual(true)
+    expect(validate('abcde')).toEqual(false)
+    expect(validate('张')).toEqual(true)
+    expect(validate('张三')).toEqual(true)
+    expect(validate('张三李')).toEqual(false)
+    expect(validate('张三a')).toEqual(false)
+    expect(validate('张ab')).toEqual(true)
+    expect(validate('1')).toEqual(true)
+    expect(validate('1234')).toEqual(true)
+    expect(validate('12345')).toEqual(false)
+  })
+
   test('rangeDelimiter', () => {
     addKeywords(ajv)
     const validate = ajv.compile({

--- a/packages/drip-form-plugin-keywords/src/keywords/gbkLength.ts
+++ b/packages/drip-form-plugin-keywords/src/keywords/gbkLength.ts
@@ -1,0 +1,45 @@
+/*
+ * @Author: jiangxiaowei
+ * @Date: 2022-01-20 19:26:31
+ * @Last Modified by: jiangxiaowei
+ * @Last Modified time: 2022-01-20 19:48:12
+ */
+
+import type { Plugin } from 'ajv/dist/2019'
+/**
+ * 计算中文、英文最长最短长度
+ * @schemaKey {number} max 最大长度
+ * @schemaKey {number} min 最短长度
+ */
+export const gbkLength: Plugin<undefined> = (ajv) => {
+  if (!ajv.getKeyword('gbkLength')) {
+    ajv.addKeyword({
+      // schema关键字
+      keyword: 'gbkLength',
+      // 允许的校验类型
+      type: 'string',
+      // modifying:true,
+      // 校验函数
+      validate: (
+        schema: {
+          max: number
+          min: number
+        },
+        data: string
+      ): boolean => {
+        const { max, min } = schema
+
+        // eslint-disable-next-line no-control-regex
+        const len = data.trim().replace(/[^\x00-\xff]/g, 'aa').length
+
+        if (min !== undefined && min > len) {
+          return false
+        } else if (max !== undefined && max < len) {
+          return false
+        }
+        return true
+      },
+    })
+  }
+  return ajv
+}

--- a/packages/drip-form-plugin-keywords/src/keywords/index.ts
+++ b/packages/drip-form-plugin-keywords/src/keywords/index.ts
@@ -1,7 +1,9 @@
 import { rangeDelimiter } from './rangeDelimiter'
+import { gbkLength } from './gbkLength'
 
-export type KeywordsName = 'rangeDelimiter'
+export type KeywordsName = 'rangeDelimiter' | 'gbkLength'
 
 export default {
   rangeDelimiter,
+  gbkLength,
 }

--- a/packages/generator/src/components/RightSideBar/Check/index.tsx
+++ b/packages/generator/src/components/RightSideBar/Check/index.tsx
@@ -4,7 +4,7 @@
  * @Author: jiangxiaowei
  * @Date: 2021-08-16 11:32:22
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-01-19 19:08:33
+ * @Last Modified time: 2022-01-20 19:51:07
  */
 import React, { useMemo, memo, useCallback } from 'react'
 import {
@@ -64,7 +64,7 @@ const CheckConfig = (): JSX.Element => {
   >((type, fieldKey) => {
     return `try {
       if(typeof props.get('${type}.${fieldKey}').data!=='number'){
-        return props.get('${type}.${fieldKey}').data
+        return !!props.get('${type}.${fieldKey}').data
       }else{
         return true
       }
@@ -138,7 +138,7 @@ const CheckConfig = (): JSX.Element => {
         fieldKey: cur,
         ui: {
           type: 'text',
-          vcontrol: vcontrol('common', cur),
+          vcontrol: vcontrol('business', cur),
         },
       })
       // 注入vcontrol

--- a/packages/generator/src/fields/common/checkConfig/String/index.ts
+++ b/packages/generator/src/fields/common/checkConfig/String/index.ts
@@ -3,7 +3,7 @@
  * @Author: jiangxiaowei
  * @Date: 2021-08-16 11:31:04
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-01-19 00:10:00
+ * @Last Modified time: 2022-01-20 19:46:55
  */
 // dataSchema2019-09支持的字符串校验关键字
 const stringJsonSchema = {
@@ -239,6 +239,40 @@ const dripFormPluginKeywords = {
           type: 'text',
         },
       },
+      {
+        type: 'number',
+        fieldKey: 'max',
+        title: '最多',
+        ui: {
+          type: 'number',
+        },
+      },
+      {
+        type: 'number',
+        fieldKey: 'min',
+        title: '最少',
+        ui: {
+          type: 'number',
+        },
+      },
+    ],
+  },
+  gbkLength: {
+    type: 'object',
+    fieldKey: 'gbkLength',
+    title: '中英文长度',
+    ui: {
+      type: 'object',
+      mode: 'collapse',
+      containerStyle: {
+        marginBottom: 0,
+      },
+      description: {
+        type: 'icon',
+        title: '中文2个字符，英文1个字符',
+      },
+    },
+    schema: [
       {
         type: 'number',
         fieldKey: 'max',


### PR DESCRIPTION
ajv默认的minLength、maxLength对于中文字符也认为是1

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

feat: ajv keyword添加gbkLength关键字

ajv默认的minLength、maxLength对于中文字符也认为是1
gbkLength中文字符2，英文字符1
### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

packages/drip-form-plugin-keywords/__tests__/index.test.ts

```
  test('gbkLength', () => {
    addKeywords(ajv)
    const validate = ajv.compile({
      type: 'string',
      gbkLength: {
        max: 4,
        min: 1,
      },
    })
    expect(validate('')).toEqual(false)
    expect(validate('a')).toEqual(true)
    expect(validate('ab')).toEqual(true)
    expect(validate('abcd')).toEqual(true)
    expect(validate('abcde')).toEqual(false)
    expect(validate('张')).toEqual(true)
    expect(validate('张三')).toEqual(true)
    expect(validate('张三李')).toEqual(false)
    expect(validate('张三a')).toEqual(false)
    expect(validate('张ab')).toEqual(true)
    expect(validate('1')).toEqual(true)
    expect(validate('1234')).toEqual(true)
    expect(validate('12345')).toEqual(false)
  })
```

## Related PRs

N