### PR TITLE
fix(generator): 修复属性配置区域数组对象结构展示标题导致样式错乱

### DIFF
--- a/packages/generator/src/fields/formItem/checkbox.field.ts
+++ b/packages/generator/src/fields/formItem/checkbox.field.ts
@@ -38,7 +38,7 @@ const config: Field = {
         items: {
           type: 'object',
           title: '',
-          ui: { type: 'object' },
+          ui: { type: 'object', showTitle: false },
           schema: [
             {
               type: 'string',

--- a/packages/generator/src/fields/formItem/radio.field.ts
+++ b/packages/generator/src/fields/formItem/radio.field.ts
@@ -41,7 +41,7 @@ const config: Field = {
         items: {
           type: 'object',
           title: '',
-          ui: { type: 'object' },
+          ui: { type: 'object', showTitle: false },
           schema: [
             {
               type: 'string',

--- a/packages/generator/src/fields/formItem/select.field.ts
+++ b/packages/generator/src/fields/formItem/select.field.ts
@@ -91,7 +91,7 @@ const config: Field = {
         items: {
           type: 'object',
           title: '',
-          ui: { type: 'object' },
+          ui: { type: 'object', showTitle: false },
           schema: [
             {
               type: 'string',

--- a/packages/generator/src/fields/formItem/slider.field.ts
+++ b/packages/generator/src/fields/formItem/slider.field.ts
@@ -141,7 +141,7 @@ const config: Field = {
         items: {
           type: 'object',
           title: '',
-          ui: { type: 'object' },
+          ui: { type: 'object', showTitle: false },
           minItems: 1,
           maxItems: 1,
           schema: [


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

generator属性配置区域数组对象容器，默认展示标题，大屏展示如下
![image](https://user-images.githubusercontent.com/19370610/153565874-c964ef6d-90f3-4cf5-8588-68cfee4dd749.png)
小屏展示如下
![image](https://user-images.githubusercontent.com/19370610/153571728-5858560d-d7fe-48cd-9532-4b2aafb00355.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N
