### PR TITLE
style: 标题颜色所有模式默认#000000

### DIFF
--- a/packages/drip-form/src/components/CommonContainerHoc/index.styl
+++ b/packages/drip-form/src/components/CommonContainerHoc/index.styl
@@ -16,6 +16,3 @@
 
 	&--content
 		width 100%
-
-	&-view
-		color rgba(0, 0, 0, 0.45)

--- a/packages/drip-form/src/render/index.tsx
+++ b/packages/drip-form/src/render/index.tsx
@@ -3,7 +3,7 @@
  * @Author: jiangxiaowei
  * @Date: 2021-07-30 16:35:48
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-03-31 11:01:34
+ * @Last Modified time: 2022-04-01 11:36:25
  */
 import React from 'react'
 import type { RenderFnProps } from './type'
@@ -173,10 +173,7 @@ const Render = ({
         verticalAlign: 'center',
         requiredFields: false,
         fontSize: 12,
-        color:
-          (uiProp.formMode || formMode) === 'view'
-            ? 'rgba(0,0,0,0.45)'
-            : '#000000',
+        color: '#000000',
       },
       globalTitleUi,
       properties[item]?.title || {}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

formMode为view时，之前默认标题为灰色。每个用户想要的颜色不一定一致
revert 5033cacd958fe01588955156d2ad1c8b98ad86fd

查看(formMode为view时)模式默认颜色和编辑(formMode为edit时)模式颜色保持一致都是#000000，定制颜色由用户控制

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

#164 