### PR TITLE
fix(generator): fix  error where value in order is not in category

### DIFF
--- a/packages/generator/src/App/index.tsx
+++ b/packages/generator/src/App/index.tsx
@@ -100,7 +100,14 @@ const Generator = forwardRef<GeneratorRef, GeneratorType>(
     // 设置左侧组件
     useEffect(() => {
       if (components) {
-        setSidebarData(components)
+        // 过滤order
+        setSidebarData(
+          produce(components, (draft) => {
+            draft.order = draft.order.filter((item) =>
+              Object.keys(draft.category).includes(item)
+            )
+          })
+        )
       } else {
         if (customComponents) {
           setSidebarData((oldSidebarData) => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

修复generator中[自定义组件区](https://jdfed.github.io/drip-form/docs/generator/props/components)，order中的值不在cateogory中导致报错的问题

* 报错例子

   ```
   components={{
          order: ['a', 'antd'],
          category: {
            a: {
              title: 'a',
              order: [],
              fields: {},
            },
          },
        }}
   ```
* 修复后，会自动过滤order中的`antd`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N
