### PR TITLE
feat(utils): parseUnitedSchema supports transparent DataSchema keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"@rollup/plugin-replace": "^2.3.2",
 		"@rollup/plugin-strip": "^1.3.3",
 		"@types/jest": "^26.0.5",
+		"@types/lodash": "^4.14.181",
 		"@types/react": "^16.9.36",
 		"@types/react-color": "^3.0.2",
 		"@types/react-dom": "^16.9.8",

--- a/packages/utils/__tests__/parse.ts
+++ b/packages/utils/__tests__/parse.ts
@@ -1,4 +1,4 @@
-import { parseUnitedSchema } from '../src/index'
+import { parseUnitedSchema, UnitedSchema } from '../src/index'
 import {
   unitedSchema as test1,
   parsedSchema as verify1,
@@ -31,45 +31,79 @@ import {
   unitedSchema as test8,
   parsedSchema as verify8,
 } from '../__testsdata__/array.schema'
+import {
+  unitedSchema as test9,
+  parsedSchema as verify9,
+} from '../__testsdata__/errMsg4.schema'
+import {
+  unitedSchema as test10,
+  parsedSchema as verify10,
+} from '../__testsdata__/root.schema'
+import {
+  unitedSchema as test11,
+  parsedSchema as verify11,
+} from '../__testsdata__/test.schema'
+import {
+  unitedSchema as test12,
+  parsedSchema as verify12,
+} from '../__testsdata__/repeatField.schema'
 
 describe('parseUnitedSchema', () => {
   test('test datePicker.schema.js', () => {
-    const data = parseUnitedSchema(test7)
+    const data = parseUnitedSchema(test7 as UnitedSchema)
     expect(data).toStrictEqual(verify7)
   })
 
   test('test multinest.schema.js', () => {
-    const data = parseUnitedSchema(test1)
+    const data = parseUnitedSchema(test1 as UnitedSchema)
     expect(data).toStrictEqual(verify1)
   })
 
   test('test nest.schema.js', () => {
-    const data = parseUnitedSchema(test2)
+    const data = parseUnitedSchema(test2 as UnitedSchema)
     expect(data).toStrictEqual(verify2)
   })
 
   test('test nestObject.schema.js', () => {
-    const data = parseUnitedSchema(test3)
+    const data = parseUnitedSchema(test3 as UnitedSchema)
     expect(data).toStrictEqual(verify3)
   })
 
   test('test errMsg.schema.js', () => {
-    const data = parseUnitedSchema(test4)
+    const data = parseUnitedSchema(test4 as UnitedSchema)
     expect(data).toStrictEqual(verify4)
   })
 
   test('test errMsg.schema2.js', () => {
-    const data = parseUnitedSchema(test5)
+    const data = parseUnitedSchema(test5 as UnitedSchema)
     expect(data).toStrictEqual(verify5)
   })
 
   test('test errMsg.schema3.js', () => {
-    const data = parseUnitedSchema(test6)
+    const data = parseUnitedSchema(test6 as UnitedSchema)
     expect(data).toStrictEqual(verify6)
   })
 
+  test('test errMsg4.schema.js', () => {
+    const data = parseUnitedSchema(test9 as UnitedSchema)
+    expect(data).toStrictEqual(verify9)
+  })
+
   test('test array.schema.js', () => {
-    const data = parseUnitedSchema(test8)
+    const data = parseUnitedSchema(test8 as UnitedSchema)
     expect(data).toStrictEqual(verify8)
+  })
+  test('test root.schema.js', () => {
+    const data = parseUnitedSchema(test10 as UnitedSchema)
+    expect(data).toStrictEqual(verify10)
+  })
+
+  test('test test.schema.js', () => {
+    const data = parseUnitedSchema(test11 as UnitedSchema)
+    expect(data).toStrictEqual(verify11)
+  })
+  test('test repeatField.schema.js', () => {
+    const data = parseUnitedSchema(test12 as UnitedSchema)
+    expect(data).toStrictEqual(verify12)
   })
 })

--- a/packages/utils/__testsdata__/array.schema.ts
+++ b/packages/utils/__testsdata__/array.schema.ts
@@ -91,4 +91,5 @@ export const parsedSchema = {
       unitedSchemaKey: 'schema.0.items',
     },
   },
+  customProps: [],
 }

--- a/packages/utils/__testsdata__/errMsg2.schema.ts
+++ b/packages/utils/__testsdata__/errMsg2.schema.ts
@@ -69,4 +69,5 @@ export const parsedSchema = {
       unitedSchemaKey: 'schema.0',
     },
   },
+  customProps: [],
 }

--- a/packages/utils/__testsdata__/errMsg3.schema.ts
+++ b/packages/utils/__testsdata__/errMsg3.schema.ts
@@ -74,4 +74,5 @@ export const parsedSchema = {
     },
     theme: 'antd',
   },
+  customProps: [],
 }

--- a/packages/utils/__testsdata__/errMsg4.schema.ts
+++ b/packages/utils/__testsdata__/errMsg4.schema.ts
@@ -3,10 +3,18 @@ export const unitedSchema = {
   validateTime: 'submit',
   requiredMode: 'default',
   type: 'object',
+  footer: {},
+  formMode: 'edit',
+  containerStyle: {},
+  'ui:a1': 1,
   ui: {
     mode: 'edit',
+    a1: 2,
+    b: 2,
     '$:type': 'drip',
   },
+  'ui:a': 1,
+  'ui:b': 1,
   schema: [
     {
       fieldKey: 'name',
@@ -80,7 +88,13 @@ export const parsedSchema = {
   },
   uiSchema: {
     theme: 'antd',
+    footer: {},
+    formMode: 'edit',
+    containerStyle: {},
     mode: 'edit',
+    a: 1,
+    a1: 2,
+    b: 2,
     order: ['name', 'babelRadio'],
     '$:type': 'drip',
     properties: {

--- a/packages/utils/__testsdata__/multinest.schema.ts
+++ b/packages/utils/__testsdata__/multinest.schema.ts
@@ -246,4 +246,5 @@ export const parsedSchema = {
       unitedSchemaKey: 'schema.1.items.schema.0.items',
     },
   },
+  customProps: [],
 }

--- a/packages/utils/__testsdata__/nest.schema.ts
+++ b/packages/utils/__testsdata__/nest.schema.ts
@@ -120,7 +120,7 @@ export const parsedSchema = {
       },
       tupleItem: {
         type: 'array',
-        order: [0, 1],
+        order: ['0', '1'],
         properties: {
           0: {
             type: 'input',
@@ -290,4 +290,5 @@ export const parsedSchema = {
       unitedSchemaKey: 'schema.3.items.schema.1',
     },
   },
+  customProps: [],
 }

--- a/packages/utils/__testsdata__/nestObject.schema.ts
+++ b/packages/utils/__testsdata__/nestObject.schema.ts
@@ -142,7 +142,7 @@ export const parsedSchema = {
       },
       tupleItem: {
         type: 'array',
-        order: [0, 1],
+        order: ['0', '1'],
         properties: {
           0: {
             type: 'input',
@@ -338,4 +338,5 @@ export const parsedSchema = {
       unitedSchemaKey: 'schema.3.items.schema.1',
     },
   },
+  customProps: [],
 }

--- a/packages/utils/__testsdata__/repeatField.schema.ts
+++ b/packages/utils/__testsdata__/repeatField.schema.ts
@@ -24,33 +24,18 @@ export const unitedSchema = {
       },
     },
     {
-      title: '下拉输入',
-      type: 'object',
-      fieldKey: 'babelRadio',
+      fieldKey: 'name',
+      title: '名字',
+      type: 'string',
+      requiredMsg: '该项必填',
       ui: {
-        type: 'selectText',
-        placeholder: '请选择',
-        allowClear: true,
-        multiple: true,
-        requestCache: true,
-        options: [
-          {
-            label: '北京',
-            value: '0',
-          },
-          {
-            label: '上海',
-            value: '1',
-          },
-          {
-            label: '成都',
-            value: '2',
-          },
-          {
-            label: '武汉',
-            value: '3',
-          },
-        ],
+        type: 'text',
+        placeholder: '请输入name，当name1有值时，该表单隐藏',
+        description: {
+          type: 'icon',
+          title: 'hover触发提示',
+          trigger: 'hover',
+        },
       },
     },
   ],
@@ -66,10 +51,6 @@ export const parsedSchema = {
         title: '名字',
         type: 'string',
       },
-      babelRadio: {
-        title: '下拉输入',
-        type: 'object',
-      },
     },
     required: ['name'],
     errorMessage: {
@@ -81,7 +62,7 @@ export const parsedSchema = {
   uiSchema: {
     theme: 'antd',
     mode: 'edit',
-    order: ['name', 'babelRadio'],
+    order: ['name'],
     '$:type': 'drip',
     properties: {
       name: {
@@ -93,43 +74,13 @@ export const parsedSchema = {
           trigger: 'hover',
         },
       },
-      babelRadio: {
-        type: 'selectText',
-        placeholder: '请选择',
-        allowClear: true,
-        multiple: true,
-        requestCache: true,
-        options: [
-          {
-            label: '北京',
-            value: '0',
-          },
-          {
-            label: '上海',
-            value: '1',
-          },
-          {
-            label: '成都',
-            value: '2',
-          },
-          {
-            label: '武汉',
-            value: '3',
-          },
-        ],
-      },
     },
   },
   typePath: {
-    babelRadio: {
-      fatherKey: '',
-      type: 'object',
-      unitedSchemaKey: 'schema.1',
-    },
     name: {
       fatherKey: '',
       type: 'string',
-      unitedSchemaKey: 'schema.0',
+      unitedSchemaKey: 'schema.1',
     },
   },
   customProps: [],

--- a/packages/utils/__testsdata__/root.schema.ts
+++ b/packages/utils/__testsdata__/root.schema.ts
@@ -1,0 +1,35 @@
+export const unitedSchema = {
+  type: 'string',
+  title: '输入框',
+  minLength: 1,
+  // fieldKey:'a',
+  errMsg: {
+    minLength: '最小1',
+  },
+  ui: {
+    type: 'text',
+    style: { width: '100%' },
+  },
+}
+
+export const parsedSchema = {
+  dataSchema: {
+    type: 'string',
+    title: '输入框',
+    minLength: 1,
+    errorMessage: {
+      minLength: '最小1',
+    },
+  },
+  uiSchema: {
+    type: 'text',
+    // fieldKey:'a',
+    style: { width: '100%' },
+  },
+  typePath: {
+    // type:'string',
+    // unitedSchemaKey:'',
+    // fatherKey:''
+  },
+  customProps: [],
+}

--- a/packages/utils/__testsdata__/test.schema.ts
+++ b/packages/utils/__testsdata__/test.schema.ts
@@ -1,0 +1,1125 @@
+/* eslint-disable quotes */
+export const unitedSchema = {
+  validateTime: 'change',
+  theme: 'antd',
+  ui: {
+    containerStyle: {
+      padding: '0 16px',
+    },
+  },
+  schema: [
+    {
+      type: 'string',
+      title: '展示模式',
+      fieldKey: 'viewMode',
+      default: 'all',
+      ui: {
+        type: 'select',
+        style: {
+          width: '100%',
+        },
+        options: [
+          {
+            value: 'configured',
+            label: '只展示已配置校验规则',
+          },
+          {
+            value: 'all',
+            label: '全部展示',
+          },
+        ],
+      },
+    },
+    {
+      type: 'object',
+      title: '通用校验',
+      fieldKey: 'common',
+      ui: {
+        type: 'object',
+        mode: 'collapse',
+        '$:dripStyle': true,
+        ghost: true,
+        containerStyle: {
+          marginBottom: 5,
+          padding: 0,
+        },
+      },
+      schema: [
+        {
+          type: 'boolean',
+          title: '是否必填',
+          fieldKey: 'required',
+          ui: {
+            type: 'switch',
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+        },
+        {
+          type: 'number',
+          fieldKey: 'minLength',
+          title: '最小长度',
+          ui: {
+            type: 'number',
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+        },
+        {
+          type: 'number',
+          fieldKey: 'maxLength',
+          title: '最大长度',
+          ui: {
+            type: 'number',
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+        },
+        {
+          type: 'string',
+          title: '正则表达式不带标志',
+          fieldKey: 'pattern',
+          ui: {
+            type: 'text',
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+        },
+        {
+          type: 'string',
+          fieldKey: 'format',
+          title: '常见正则',
+          ui: {
+            type: 'select',
+            style: {
+              width: '100%',
+            },
+            allowClear: true,
+            options: [
+              {
+                value: 'color',
+                label: 'color',
+              },
+              {
+                value: 'https',
+                label: 'https',
+              },
+              {
+                value: 'jsonObject',
+                label: 'jsonObject',
+              },
+              {
+                value: 'date',
+                label: 'date',
+              },
+              {
+                value: 'time',
+                label: 'time',
+              },
+              {
+                value: 'date-tiem',
+                label: 'date-time',
+              },
+              {
+                value: 'duration',
+                label: 'duration',
+              },
+              {
+                value: 'uri',
+                label: 'uri',
+              },
+              {
+                value: 'uri-reference',
+                label: 'uri-reference',
+              },
+              {
+                value: 'uri-template',
+                label: 'uri-template',
+              },
+              {
+                value: 'url',
+                label: 'url',
+              },
+              {
+                value: 'email',
+                label: 'email',
+              },
+              {
+                value: 'hostname',
+                label: 'hostname',
+              },
+              {
+                value: 'ipv4',
+                label: 'ipv4',
+              },
+              {
+                value: 'ipv6',
+                label: 'ipv6',
+              },
+              {
+                value: 'regex',
+                label: 'regex',
+              },
+              {
+                value: 'uuid',
+                label: 'uuid',
+              },
+              {
+                value: 'json-pointer',
+                label: 'json-pointer',
+              },
+              {
+                value: 'relative-json-pointer',
+                label: 'relative-json-pointer',
+              },
+              {
+                value: 'byte',
+                label: 'byte',
+              },
+              {
+                value: 'int32',
+                label: 'int32',
+              },
+              {
+                value: 'int64',
+                label: 'int64',
+              },
+              {
+                value: 'float',
+                label: 'float',
+              },
+              {
+                value: 'double',
+                label: 'double',
+              },
+              {
+                value: 'password',
+                label: 'password',
+              },
+              {
+                value: 'binary',
+                label: 'binary',
+              },
+            ],
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+        },
+        {
+          type: 'string',
+          fieldKey: 'regexp',
+          title: '正则表达带标志·',
+          ui: {
+            description: {
+              type: 'icon',
+              trigger: 'hover',
+              title: '可以使用g、i、u等正则标志',
+            },
+            type: 'text',
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+        },
+        {
+          type: 'array',
+          fieldKey: 'transform',
+          title: '格式化',
+          ui: {
+            type: 'select',
+            style: {
+              width: '100%',
+            },
+            mode: 'multiple',
+            options: [
+              {
+                value: 'trim',
+                label: '去除首尾空格',
+              },
+              {
+                value: 'trimStart',
+                label: '去除开始的空格',
+              },
+              {
+                value: 'trimEnd',
+                label: '去除尾部的空格',
+              },
+              {
+                value: 'toLowerCase',
+                label: '转换为小写',
+              },
+              {
+                value: 'trimUpperCase',
+                label: '转换为大写',
+              },
+            ],
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+        },
+      ],
+    },
+    {
+      type: 'object',
+      title: '业务校验',
+      fieldKey: 'business',
+      ui: {
+        type: 'object',
+        mode: 'collapse',
+        '$:dripStyle': true,
+        ghost: true,
+        containerStyle: {
+          padding: 0,
+          marginBottom: 5,
+        },
+      },
+      schema: [
+        {
+          type: 'object',
+          fieldKey: 'rangeDelimiter',
+          title: '分隔符范围',
+          ui: {
+            type: 'object',
+            mode: 'collapse',
+            '$:dripStyle': true,
+            ghost: true,
+            containerStyle: {
+              padding: 0,
+              marginBottom: 5,
+            },
+            description: {
+              type: 'icon',
+              title: '使用delimiter指定的字符分隔，最少多少，最多多少',
+            },
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+          schema: [
+            {
+              type: 'string',
+              fieldKey: 'delimiter',
+              title: '自定义分隔符',
+              ui: {
+                type: 'text',
+              },
+            },
+            {
+              type: 'number',
+              fieldKey: 'max',
+              title: '最多',
+              ui: {
+                type: 'number',
+              },
+            },
+            {
+              type: 'number',
+              fieldKey: 'min',
+              title: '最少',
+              ui: {
+                type: 'number',
+              },
+            },
+          ],
+        },
+        {
+          type: 'object',
+          fieldKey: 'gbkLength',
+          title: '中英文长度',
+          ui: {
+            type: 'object',
+            mode: 'collapse',
+            '$:dripStyle': true,
+            ghost: true,
+            containerStyle: {
+              padding: 0,
+              marginBottom: 5,
+            },
+            description: {
+              type: 'icon',
+              title: '中文2个字符，英文1个字符',
+            },
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+          schema: [
+            {
+              type: 'number',
+              fieldKey: 'max',
+              title: '最多',
+              ui: {
+                type: 'number',
+              },
+            },
+            {
+              type: 'number',
+              fieldKey: 'min',
+              title: '最少',
+              ui: {
+                type: 'number',
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'object',
+      title: '校验错误文案配置',
+      fieldKey: 'errorMessage',
+      ui: {
+        type: 'object',
+        mode: 'collapse',
+        '$:dripStyle': true,
+        ghost: true,
+        containerStyle: {
+          padding: 0,
+          marginBottom: 5,
+        },
+      },
+      schema: [
+        {
+          type: 'string',
+          title: '错误兜底文案',
+          fieldKey: '_',
+          ui: {
+            type: 'text',
+            description: {
+              type: 'icon',
+              trigger: 'hover',
+              title: '当关键字未配置错误文案时，发生错误会展示该文案',
+            },
+          },
+        },
+        {
+          type: 'string',
+          title: '是否必填',
+          fieldKey: 'required',
+          ui: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.required').data!=='number'){\n        return !!props.get('common.required').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+        },
+        {
+          type: 'string',
+          title: '最小长度',
+          fieldKey: 'minLength',
+          ui: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.minLength').data!=='number'){\n        return !!props.get('common.minLength').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+        },
+        {
+          type: 'string',
+          title: '最大长度',
+          fieldKey: 'maxLength',
+          ui: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.maxLength').data!=='number'){\n        return !!props.get('common.maxLength').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+        },
+        {
+          type: 'string',
+          title: '正则表达式不带标志',
+          fieldKey: 'pattern',
+          ui: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.pattern').data!=='number'){\n        return !!props.get('common.pattern').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+        },
+        {
+          type: 'string',
+          title: '常见正则',
+          fieldKey: 'format',
+          ui: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.format').data!=='number'){\n        return !!props.get('common.format').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+        },
+        {
+          type: 'string',
+          title: '正则表达带标志·',
+          fieldKey: 'regexp',
+          ui: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.regexp').data!=='number'){\n        return !!props.get('common.regexp').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+        },
+        {
+          type: 'string',
+          title: '格式化',
+          fieldKey: 'transform',
+          ui: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.transform').data!=='number'){\n        return !!props.get('common.transform').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+        },
+        {
+          type: 'string',
+          title: '分隔符范围',
+          fieldKey: 'rangeDelimiter',
+          ui: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('business.rangeDelimiter').data!=='number'){\n        return !!props.get('business.rangeDelimiter').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+        },
+        {
+          type: 'string',
+          title: '中英文长度',
+          fieldKey: 'gbkLength',
+          ui: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('business.gbkLength').data!=='number'){\n        return !!props.get('business.gbkLength').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+        },
+      ],
+    },
+  ],
+}
+
+export const parsedSchema = {
+  dataSchema: {
+    validateTime: 'change',
+    type: 'object',
+    properties: {
+      viewMode: {
+        type: 'string',
+        title: '展示模式',
+        default: 'all',
+      },
+      common: {
+        type: 'object',
+        title: '通用校验',
+        properties: {
+          required: {
+            type: 'boolean',
+            title: '是否必填',
+          },
+          minLength: {
+            type: 'number',
+            title: '最小长度',
+          },
+          maxLength: {
+            type: 'number',
+            title: '最大长度',
+          },
+          pattern: {
+            type: 'string',
+            title: '正则表达式不带标志',
+          },
+          format: {
+            type: 'string',
+            title: '常见正则',
+          },
+          regexp: {
+            type: 'string',
+            title: '正则表达带标志·',
+          },
+          transform: {
+            type: 'array',
+            title: '格式化',
+          },
+        },
+      },
+      business: {
+        type: 'object',
+        title: '业务校验',
+        properties: {
+          rangeDelimiter: {
+            type: 'object',
+            title: '分隔符范围',
+            properties: {
+              delimiter: {
+                type: 'string',
+                title: '自定义分隔符',
+              },
+              max: {
+                type: 'number',
+                title: '最多',
+              },
+              min: {
+                type: 'number',
+                title: '最少',
+              },
+            },
+          },
+          gbkLength: {
+            type: 'object',
+            title: '中英文长度',
+            properties: {
+              max: {
+                type: 'number',
+                title: '最多',
+              },
+              min: {
+                type: 'number',
+                title: '最少',
+              },
+            },
+          },
+        },
+      },
+      errorMessage: {
+        type: 'object',
+        title: '校验错误文案配置',
+        properties: {
+          _: {
+            type: 'string',
+            title: '错误兜底文案',
+          },
+          required: {
+            type: 'string',
+            title: '是否必填',
+          },
+          minLength: {
+            type: 'string',
+            title: '最小长度',
+          },
+          maxLength: {
+            type: 'string',
+            title: '最大长度',
+          },
+          pattern: {
+            type: 'string',
+            title: '正则表达式不带标志',
+          },
+          format: {
+            type: 'string',
+            title: '常见正则',
+          },
+          regexp: {
+            type: 'string',
+            title: '正则表达带标志·',
+          },
+          transform: {
+            type: 'string',
+            title: '格式化',
+          },
+          rangeDelimiter: {
+            type: 'string',
+            title: '分隔符范围',
+          },
+          gbkLength: {
+            type: 'string',
+            title: '中英文长度',
+          },
+        },
+      },
+    },
+  },
+  uiSchema: {
+    theme: 'antd',
+    containerStyle: {
+      padding: '0 16px',
+    },
+    order: ['viewMode', 'common', 'business', 'errorMessage'],
+    properties: {
+      viewMode: {
+        type: 'select',
+        style: {
+          width: '100%',
+        },
+        options: [
+          {
+            value: 'configured',
+            label: '只展示已配置校验规则',
+          },
+          {
+            value: 'all',
+            label: '全部展示',
+          },
+        ],
+      },
+      common: {
+        type: 'object',
+        mode: 'collapse',
+        '$:dripStyle': true,
+        ghost: true,
+        containerStyle: {
+          marginBottom: 5,
+          padding: 0,
+        },
+        order: [
+          'required',
+          'minLength',
+          'maxLength',
+          'pattern',
+          'format',
+          'regexp',
+          'transform',
+        ],
+        properties: {
+          required: {
+            type: 'switch',
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+          minLength: {
+            type: 'number',
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+          maxLength: {
+            type: 'number',
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+          pattern: {
+            type: 'text',
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+          format: {
+            type: 'select',
+            style: {
+              width: '100%',
+            },
+            allowClear: true,
+            options: [
+              {
+                value: 'color',
+                label: 'color',
+              },
+              {
+                value: 'https',
+                label: 'https',
+              },
+              {
+                value: 'jsonObject',
+                label: 'jsonObject',
+              },
+              {
+                value: 'date',
+                label: 'date',
+              },
+              {
+                value: 'time',
+                label: 'time',
+              },
+              {
+                value: 'date-tiem',
+                label: 'date-time',
+              },
+              {
+                value: 'duration',
+                label: 'duration',
+              },
+              {
+                value: 'uri',
+                label: 'uri',
+              },
+              {
+                value: 'uri-reference',
+                label: 'uri-reference',
+              },
+              {
+                value: 'uri-template',
+                label: 'uri-template',
+              },
+              {
+                value: 'url',
+                label: 'url',
+              },
+              {
+                value: 'email',
+                label: 'email',
+              },
+              {
+                value: 'hostname',
+                label: 'hostname',
+              },
+              {
+                value: 'ipv4',
+                label: 'ipv4',
+              },
+              {
+                value: 'ipv6',
+                label: 'ipv6',
+              },
+              {
+                value: 'regex',
+                label: 'regex',
+              },
+              {
+                value: 'uuid',
+                label: 'uuid',
+              },
+              {
+                value: 'json-pointer',
+                label: 'json-pointer',
+              },
+              {
+                value: 'relative-json-pointer',
+                label: 'relative-json-pointer',
+              },
+              {
+                value: 'byte',
+                label: 'byte',
+              },
+              {
+                value: 'int32',
+                label: 'int32',
+              },
+              {
+                value: 'int64',
+                label: 'int64',
+              },
+              {
+                value: 'float',
+                label: 'float',
+              },
+              {
+                value: 'double',
+                label: 'double',
+              },
+              {
+                value: 'password',
+                label: 'password',
+              },
+              {
+                value: 'binary',
+                label: 'binary',
+              },
+            ],
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+          regexp: {
+            description: {
+              type: 'icon',
+              trigger: 'hover',
+              title: '可以使用g、i、u等正则标志',
+            },
+            type: 'text',
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+          transform: {
+            type: 'select',
+            style: {
+              width: '100%',
+            },
+            mode: 'multiple',
+            options: [
+              {
+                value: 'trim',
+                label: '去除首尾空格',
+              },
+              {
+                value: 'trimStart',
+                label: '去除开始的空格',
+              },
+              {
+                value: 'trimEnd',
+                label: '去除尾部的空格',
+              },
+              {
+                value: 'toLowerCase',
+                label: '转换为小写',
+              },
+              {
+                value: 'trimUpperCase',
+                label: '转换为大写',
+              },
+            ],
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+          },
+        },
+      },
+      business: {
+        type: 'object',
+        mode: 'collapse',
+        '$:dripStyle': true,
+        ghost: true,
+        containerStyle: {
+          padding: 0,
+          marginBottom: 5,
+        },
+        order: ['rangeDelimiter', 'gbkLength'],
+        properties: {
+          rangeDelimiter: {
+            type: 'object',
+            mode: 'collapse',
+            '$:dripStyle': true,
+            ghost: true,
+            containerStyle: {
+              padding: 0,
+              marginBottom: 5,
+            },
+            description: {
+              type: 'icon',
+              title: '使用delimiter指定的字符分隔，最少多少，最多多少',
+            },
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+            order: ['delimiter', 'max', 'min'],
+            properties: {
+              delimiter: {
+                type: 'text',
+              },
+              max: {
+                type: 'number',
+              },
+              min: {
+                type: 'number',
+              },
+            },
+          },
+          gbkLength: {
+            type: 'object',
+            mode: 'collapse',
+            '$:dripStyle': true,
+            ghost: true,
+            containerStyle: {
+              padding: 0,
+              marginBottom: 5,
+            },
+            description: {
+              type: 'icon',
+              title: '中文2个字符，英文1个字符',
+            },
+            vcontrol:
+              'const {fieldKey,formData,get}=props;return formData.viewMode==="configured"?typeof get(fieldKey).data!==\'number\'? get(fieldKey).data:true:true',
+            order: ['max', 'min'],
+            properties: {
+              max: {
+                type: 'number',
+              },
+              min: {
+                type: 'number',
+              },
+            },
+          },
+        },
+      },
+      errorMessage: {
+        type: 'object',
+        mode: 'collapse',
+        '$:dripStyle': true,
+        ghost: true,
+        containerStyle: {
+          padding: 0,
+          marginBottom: 5,
+        },
+        order: [
+          '_',
+          'required',
+          'minLength',
+          'maxLength',
+          'pattern',
+          'format',
+          'regexp',
+          'transform',
+          'rangeDelimiter',
+          'gbkLength',
+        ],
+        properties: {
+          _: {
+            type: 'text',
+            description: {
+              type: 'icon',
+              trigger: 'hover',
+              title: '当关键字未配置错误文案时，发生错误会展示该文案',
+            },
+          },
+          required: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.required').data!=='number'){\n        return !!props.get('common.required').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+          minLength: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.minLength').data!=='number'){\n        return !!props.get('common.minLength').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+          maxLength: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.maxLength').data!=='number'){\n        return !!props.get('common.maxLength').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+          pattern: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.pattern').data!=='number'){\n        return !!props.get('common.pattern').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+          format: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.format').data!=='number'){\n        return !!props.get('common.format').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+          regexp: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.regexp').data!=='number'){\n        return !!props.get('common.regexp').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+          transform: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('common.transform').data!=='number'){\n        return !!props.get('common.transform').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+          rangeDelimiter: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('business.rangeDelimiter').data!=='number'){\n        return !!props.get('business.rangeDelimiter').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+          gbkLength: {
+            type: 'text',
+            vcontrol:
+              "try {\n      if(typeof props.get('business.gbkLength').data!=='number'){\n        return !!props.get('business.gbkLength').data\n      }else{\n        return true\n      }\n    } catch (error) {\n      return false\n    }",
+          },
+        },
+      },
+    },
+  },
+  typePath: {
+    viewMode: {
+      fatherKey: '',
+      unitedSchemaKey: 'schema.0',
+      type: 'string',
+    },
+    common: {
+      fatherKey: '',
+      unitedSchemaKey: 'schema.1',
+      type: 'object',
+    },
+    'common.required': {
+      fatherKey: 'common',
+      unitedSchemaKey: 'schema.1.schema.0',
+      type: 'boolean',
+    },
+    'common.minLength': {
+      fatherKey: 'common',
+      unitedSchemaKey: 'schema.1.schema.1',
+      type: 'number',
+    },
+    'common.maxLength': {
+      fatherKey: 'common',
+      unitedSchemaKey: 'schema.1.schema.2',
+      type: 'number',
+    },
+    'common.pattern': {
+      fatherKey: 'common',
+      unitedSchemaKey: 'schema.1.schema.3',
+      type: 'string',
+    },
+    'common.format': {
+      fatherKey: 'common',
+      unitedSchemaKey: 'schema.1.schema.4',
+      type: 'string',
+    },
+    'common.regexp': {
+      fatherKey: 'common',
+      unitedSchemaKey: 'schema.1.schema.5',
+      type: 'string',
+    },
+    'common.transform': {
+      fatherKey: 'common',
+      unitedSchemaKey: 'schema.1.schema.6',
+      type: 'array',
+    },
+    business: {
+      fatherKey: '',
+      unitedSchemaKey: 'schema.2',
+      type: 'object',
+    },
+    'business.rangeDelimiter': {
+      fatherKey: 'business',
+      unitedSchemaKey: 'schema.2.schema.0',
+      type: 'object',
+    },
+    'business.rangeDelimiter.delimiter': {
+      fatherKey: 'business.rangeDelimiter',
+      unitedSchemaKey: 'schema.2.schema.0.schema.0',
+      type: 'string',
+    },
+    'business.rangeDelimiter.max': {
+      fatherKey: 'business.rangeDelimiter',
+      unitedSchemaKey: 'schema.2.schema.0.schema.1',
+      type: 'number',
+    },
+    'business.rangeDelimiter.min': {
+      fatherKey: 'business.rangeDelimiter',
+      unitedSchemaKey: 'schema.2.schema.0.schema.2',
+      type: 'number',
+    },
+    'business.gbkLength': {
+      fatherKey: 'business',
+      unitedSchemaKey: 'schema.2.schema.1',
+      type: 'object',
+    },
+    'business.gbkLength.max': {
+      fatherKey: 'business.gbkLength',
+      unitedSchemaKey: 'schema.2.schema.1.schema.0',
+      type: 'number',
+    },
+    'business.gbkLength.min': {
+      fatherKey: 'business.gbkLength',
+      unitedSchemaKey: 'schema.2.schema.1.schema.1',
+      type: 'number',
+    },
+    errorMessage: {
+      fatherKey: '',
+      unitedSchemaKey: 'schema.3',
+      type: 'object',
+    },
+    'errorMessage._': {
+      fatherKey: 'errorMessage',
+      unitedSchemaKey: 'schema.3.schema.0',
+      type: 'string',
+    },
+    'errorMessage.required': {
+      fatherKey: 'errorMessage',
+      unitedSchemaKey: 'schema.3.schema.1',
+      type: 'string',
+    },
+    'errorMessage.minLength': {
+      fatherKey: 'errorMessage',
+      unitedSchemaKey: 'schema.3.schema.2',
+      type: 'string',
+    },
+    'errorMessage.maxLength': {
+      fatherKey: 'errorMessage',
+      unitedSchemaKey: 'schema.3.schema.3',
+      type: 'string',
+    },
+    'errorMessage.pattern': {
+      fatherKey: 'errorMessage',
+      unitedSchemaKey: 'schema.3.schema.4',
+      type: 'string',
+    },
+    'errorMessage.format': {
+      fatherKey: 'errorMessage',
+      unitedSchemaKey: 'schema.3.schema.5',
+      type: 'string',
+    },
+    'errorMessage.regexp': {
+      fatherKey: 'errorMessage',
+      unitedSchemaKey: 'schema.3.schema.6',
+      type: 'string',
+    },
+    'errorMessage.transform': {
+      fatherKey: 'errorMessage',
+      unitedSchemaKey: 'schema.3.schema.7',
+      type: 'string',
+    },
+    'errorMessage.rangeDelimiter': {
+      fatherKey: 'errorMessage',
+      unitedSchemaKey: 'schema.3.schema.8',
+      type: 'string',
+    },
+    'errorMessage.gbkLength': {
+      fatherKey: 'errorMessage',
+      unitedSchemaKey: 'schema.3.schema.9',
+      type: 'string',
+    },
+  },
+  customProps: [],
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,7 +31,8 @@
 		"url": "https://github.com/JDFED/drip-form/"
 	},
 	"dependencies": {
-		"@babel/runtime": "^7.10.2"
+		"@babel/runtime": "^7.10.2",
+		"lodash": "^4.17.21"
 	},
 	"gitHead": "1416735284b5c9f0d76c7271117fb8723a2300ec"
 }

--- a/packages/utils/src/schemaHandle/parse.ts
+++ b/packages/utils/src/schemaHandle/parse.ts
@@ -1,273 +1,251 @@
 /**
  * 联合Schema解析函数
  */
-import { judgeAndRegister, isEmpty } from '../common'
-import { FieldAtomType, UiSchema, UnitedSchema, DataSchema } from './types'
+import { typeCheck, setDeepProp } from '../common'
+import { UiSchema, UnitedSchema, DataSchema } from './types'
+import _ from 'lodash'
 import type { Map } from '../common/type'
 
 /**
- * 递归解析Schema
- * @param {FieldAtomType} item 待解析的联合schema的某个子节点
- * @param {FieldAtomType} fatherItem 待解析的某个联合schema的父级节点
- * @param {number | '$container'} idx 子节点的序号，或是作为容器的标识
- * @param {'items' | 'properties'} containerKey 读取dataSchema所需的容器字段
- * @param {DataSchema} currLevelDataSchema 当前父节点的dataSchema
- * @param {UiSchema} currLevelUiSchema 当前父节点的uiSchema
- * @param typePath
- * @param fatherPath
- * @param customProps 自定义属性的收集存储
+ * 递归解析
  */
-function recursiveParse(
-  item: FieldAtomType,
-  fatherItem: FieldAtomType,
-  idx: number | '$container',
-  containerKey: 'items' | 'properties',
-  currLevelDataSchema: DataSchema,
-  currLevelUiSchema: UiSchema,
-  typePath: Map,
-  fatherPath: string,
-  customProps: any[]
-) {
-  // 获取表单项标识符
-  const fieldKey = item.fieldKey || idx
-
-  // 获取父级元素的ui类型
-  const fatherUiType = fatherItem.ui?.type || fatherItem['ui:type']
-  // 填充typePath（type为dataSchema的类型）
-  const currKeyPath = `${fatherPath === '' ? '' : fatherPath + '.'}${fieldKey}`
-  typePath[currKeyPath] = {
-    fatherKey: fatherPath,
-    unitedSchemaKey: `${
-      typePath[fatherPath]?.unitedSchemaKey
-        ? `${typePath[fatherPath]?.unitedSchemaKey}.`
-        : ''
-    }${containerKey === 'properties' ? 'schema' : 'items'}${
-      idx !== '$container' ? `.${idx}` : ''
-    }`,
-    type: item.type,
-  }
-  // 如果是数组或对象容器（undefined默认为对象容器），则需要创建order字段用于ui渲染
-  if (
-    fatherUiType === 'array' ||
-    fatherUiType === 'object' ||
-    fatherUiType === undefined
-  ) {
-    // 判断currLevelUiSchema是否存在order属性，如果没有则创建
-    judgeAndRegister(currLevelUiSchema, 'array', 'order')
-  }
-
-  // 待渲染表单中不包含当前项时，填充进order，可作为表单的展示顺序
-  if (currLevelUiSchema.order && !currLevelUiSchema.order.includes(fieldKey)) {
-    currLevelUiSchema.order.push(fieldKey)
-  }
-
-  // 开始解析表单配置项
-  for (const key in item) {
-    if (Object.prototype.hasOwnProperty.call(item, key)) {
-      // 当前表单配置项是否为UI Props
-      const isUiProp = /^ui:/.test(key) || key === 'ui'
-
-      if (isUiProp) {
-        // 判断uiSchema是否有properties.[fieldKey]属性，没有则创建
-        judgeAndRegister(currLevelUiSchema, 'object', 'properties', fieldKey)
-
-        // 对于 { ui: { title: {}, ... } } 类型的解析
-        if (key === 'ui') {
-          Object.assign(currLevelUiSchema.properties[fieldKey], {
-            ...item[key],
-          })
-        } else {
-          // 对于 { 'ui:xxx': {}, 'ui:yyy': {} } 类型的解析
-          currLevelUiSchema.properties[fieldKey][key.slice(3)] = item[key]
-        }
-      } else {
-        switch (key) {
-          case 'schema':
-          case 'items':
-            // 处理对象嵌套
-            initParse(
-              item,
-              fieldKey === '$container'
-                ? (judgeAndRegister(
-                    currLevelDataSchema,
-                    'object',
-                    containerKey
-                  ) as DataSchema)
-                : (judgeAndRegister(
-                    currLevelDataSchema,
-                    'object',
-                    containerKey,
-                    fieldKey
-                  ) as DataSchema),
-              judgeAndRegister(
-                currLevelUiSchema,
-                'object',
-                'properties',
-                fieldKey
-              ) as UiSchema,
-              typePath,
-              currKeyPath,
-              customProps
-            )
-            break
-          case 'requiredMsg':
-            judgeAndRegister(currLevelDataSchema, 'array', 'required')
-            judgeAndRegister(
-              currLevelDataSchema,
-              'object',
-              'errorMessage',
-              'required'
-            )
-            // 必填项报错信息解析
-            if (item[key]) {
-              if (currLevelDataSchema.required) {
-                currLevelDataSchema.required.push(fieldKey)
-              }
-              if (currLevelDataSchema.errorMessage) {
-                currLevelDataSchema.errorMessage.required[fieldKey] = item[key]
-              }
-            }
-            break
-          case 'errMsg':
-            if (fieldKey !== '$container') {
-              judgeAndRegister(
-                currLevelDataSchema,
-                'object',
-                containerKey,
-                fieldKey
-              )
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              currLevelDataSchema[containerKey][fieldKey].errorMessage =
-                item[key]
-            } else {
-              judgeAndRegister(currLevelDataSchema, 'object', containerKey)
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              currLevelDataSchema[containerKey].errorMessage = item[key]
-            }
-            // 兜底报错信息解析
-            break
-          default:
-            if (key !== 'fieldKey') {
-              // 判断并收集自定义属性
-              if (key.match(/^\$:/)) {
-                customProps.push(key)
-              }
-
-              if (fieldKey === '$container') {
-                judgeAndRegister(currLevelDataSchema, 'object', containerKey)
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                currLevelDataSchema[containerKey][key] = item[key]
-              } else {
-                // 如果不存在fieldKey，则认为为元组类型的子项，需要将container创建为item类型
-                if (item.fieldKey === undefined) {
-                  judgeAndRegister(currLevelDataSchema, 'array', containerKey)
-                }
-                judgeAndRegister(
-                  currLevelDataSchema,
-                  'object',
-                  containerKey,
-                  fieldKey
-                )
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                currLevelDataSchema[containerKey][fieldKey][key] = item[key]
-              }
-            }
-        }
+function initParse({
+  unitedSchema,
+  parentType,
+  idx,
+  // 父级uiSchema
+  parentUiSchema,
+  // 父级dataSchema
+  parentDataSchema,
+  customProps,
+  typePath,
+  parentTypePath = '',
+  index,
+}: {
+  unitedSchema: UnitedSchema
+  parentType?: 'array' | 'tuple' | 'object'
+  idx?: string
+  parentUiSchema: UiSchema
+  parentDataSchema: DataSchema
+  customProps: string[]
+  typePath: Map
+  parentTypePath?: string
+  index?: string | number
+}) {
+  // 当前uiSchema
+  let curUiSchema = parentUiSchema
+  // 当前dataSchema
+  let curDataSchema = parentDataSchema
+  // 当前的typePath的key
+  let curTypePath = parentTypePath
+  // 非第一次调用initParse
+  if (idx) {
+    // 设置typePath
+    curTypePath = parentTypePath ? `${parentTypePath}.${idx}` : idx
+    typePath[curTypePath] = {
+      fatherKey: parentTypePath,
+      type: unitedSchema.type,
+      unitedSchemaKey: `${
+        typePath[parentTypePath]?.unitedSchemaKey
+          ? `${typePath[parentTypePath]?.unitedSchemaKey}.`
+          : ''
+      }${parentType == 'object' ? 'schema' : 'items'}${
+        index !== '$container' ? `.${index}` : ''
+      }`,
+    }
+  } else {
+    // 设置根元素的typePath
+    if (unitedSchema.fieldKey) {
+      typePath[unitedSchema.fieldKey] = {
+        type: unitedSchema.type,
+        unitedSchemaKey: '',
+        fatherKey: '',
       }
     }
+    // 根元素type默认为object
+    curDataSchema.type = 'object'
   }
-}
-
-/**
- * 初始化解析
- * @param {Map} schema 待解析的联合schema根节点或某个父节点
- * @param {DataSchema} dataSchema 在dataSchema上截取的当前节点的部分
- * @param {UiSchema} uiSchema 同上，但在uiSchema上
- * @param typePath
- * @param customProps 用户的所有$开头的自定义属性，用于在ajv中注册
- * @param fatherPath
- * @param {Boolean} fromRoot 是否来自根节点
- */
-function initParse(
-  schema: Map,
-  dataSchema: DataSchema,
-  uiSchema: UiSchema,
-  typePath: Map,
-  fatherPath = '',
-  customProps: any[],
-  fromRoot = false
-) {
-  // 判断下一阶段递归需要读取的容器字段，items标识父节点为数组结构，properties标识为对象结构
-  const containerKey = schema?.type === 'array' ? 'items' : 'properties'
-  // 对于对象结构而言，待递归的子节点在schema中，否则，对于数组而言在items中（依据JSON Schema协议规范）
-  const waitToParse = schema?.schema || schema?.items || []
-
-  // 由于items存在数组和对象两种形式，此处需要判断后走不同的处理逻辑
-  if (Array.isArray(waitToParse)) {
-    waitToParse.forEach((item, idx) => {
-      // 数组结构，遍历递归解析
-      recursiveParse(
-        item,
-        schema,
-        idx,
-        containerKey,
-        dataSchema,
-        uiSchema,
-        typePath,
-        fatherPath,
-        customProps
-      )
-    })
-  } else if (typeof schema.items === 'object') {
-    // 默认在dataSchema中items为数组格式，针对对象格式的，需要将其置为对象
-    // 否则会出现对象key访问数组下标的问题
-    dataSchema.items = {}
-    // 对象结构递归
-    recursiveParse(
-      schema.items,
-      schema,
-      '$container',
-      containerKey,
-      dataSchema,
-      uiSchema,
-      typePath,
-      fatherPath,
-      customProps
-    )
-  } else {
-    throw fromRoot
-      ? '表单必须要有items或schema才能开始解析！'
-      : `${schema.fieldKey || ''}的解析出现错误！`
+  // ui:开头的
+  const uiReg = /^ui:/
+  // 是否是uiSchema中的属性
+  const isUiProp = (key: string): boolean => {
+    // 需要丢到uiSchema中的属性
+    const uiSchemaKeys = ['footer', 'theme', 'containerStyle', 'formMode', 'ui']
+    return uiSchemaKeys.includes(key) || uiReg.test(key)
   }
-}
-
-/**
- * 处理联合schema中不在items或property的自定义属性
- * @param unitedSchema
- * @param customProps
- */
-function handleFirstLevelCustomDataProps(
-  unitedSchema: UnitedSchema,
-  customProps: any[]
-): Map {
-  const customDataSchema: Map = {}
-  // 遍历联合schema
-  for (const key in unitedSchema) {
-    // 如果是 $: 开头的自定义属性，则加入自定义属性中
-    if (
-      Object.prototype.hasOwnProperty.call(unitedSchema, key) &&
-      key.match(/^\$:/)
-    ) {
-      customDataSchema[key] = unitedSchema[key]
-      customProps.push(key)
+  Object.entries(unitedSchema).map(([key, value]) => {
+    // 设置uiSchema
+    if (isUiProp(key)) {
+      // 非第一次调用initParse
+      if (idx) {
+        const path = ['properties', idx]
+        setDeepProp(path, parentUiSchema, {})
+        curUiSchema = parentUiSchema.properties[idx] as UiSchema
+        // 设置order
+        const order = _.get(parentUiSchema, 'order', [] as string[])
+        // 避免重复fieldKey
+        if (!order.includes(idx)) {
+          order.push(idx)
+        }
+        parentUiSchema.order = order
+      }
+      // 设置ui:开头的ui属性，ui:{}优先级更高
+      if (uiReg.test(key)) {
+        curUiSchema[key.slice(3)] =
+          ((unitedSchema?.ui || {}) as Map)[key.slice(3)] || value
+      } else if (key === 'ui') {
+        // 设置ui:{}中的属性
+        Object.entries(value).map(([key, value]) => {
+          curUiSchema[key] = value
+        })
+      } else {
+        curUiSchema[key] = value
+      }
+    } else {
+      // 设置dataSchema
+      // 非第一次调用initParse
+      if (idx) {
+        switch (parentType) {
+          case 'object': {
+            const path = ['properties', idx]
+            setDeepProp(
+              path,
+              parentDataSchema,
+              _.get(parentDataSchema, path, {})
+            )
+            curDataSchema = (
+              parentDataSchema.properties as Record<string, DataSchema>
+            )[idx]
+            break
+          }
+          case 'array': {
+            const path = ['items']
+            setDeepProp(
+              ['items'],
+              parentDataSchema,
+              _.get(parentDataSchema, path, {})
+            )
+            curDataSchema = parentDataSchema.items as DataSchema
+            break
+          }
+          case 'tuple': {
+            const path = ['items', idx]
+            setDeepProp(
+              path,
+              parentDataSchema,
+              _.get(parentDataSchema, path, {}),
+              { items: { type: 'array' } }
+            )
+            curDataSchema = (parentDataSchema.items as DataSchema[])[
+              Number(idx)
+            ]
+            break
+          }
+          default:
+            break
+        }
+      }
+      switch (key) {
+        case 'requiredMsg':
+          // 设置父级，只有对象才有
+          if (parentType === 'object' && idx) {
+            // 设置order
+            const required = _.get(parentDataSchema, 'required', [] as string[])
+            // 避免重复fieldKey
+            if (!required.includes(idx)) {
+              required.push(idx)
+            }
+            parentDataSchema.required = required
+            setDeepProp(
+              ['errorMessage', 'required', idx],
+              parentDataSchema,
+              value
+            )
+          }
+          break
+        // 错误信息配置
+        case 'errMsg':
+          curDataSchema.errorMessage = value
+          break
+        // 以下字段 items、 schema、fieldKey 不设置到dataSchema中
+        case 'items':
+        case 'schema':
+        case 'fieldKey':
+          break
+        default:
+          // 设置customProps
+          if (/^\$:/.test(key)) {
+            customProps.push(key)
+          }
+          curDataSchema[key] = value
+          break
+      }
     }
-  }
+  })
 
-  return customDataSchema
+  // 当前表单嵌套类型  'schema'为object|'items'为array
+  let type = 'object'
+  if (unitedSchema.items) {
+    type = 'array'
+  }
+  switch (type) {
+    case 'object': {
+      // 处理通用逻辑
+      // 对schema处理（子表单处理，递归）
+      unitedSchema.schema?.map((childUnitedSchema, i) => {
+        initParse({
+          unitedSchema: childUnitedSchema,
+          idx: childUnitedSchema.fieldKey,
+          parentType: 'object',
+          parentUiSchema: curUiSchema,
+          parentDataSchema: curDataSchema,
+          parentTypePath: curTypePath,
+          customProps,
+          typePath,
+          index: i,
+        })
+      })
+      break
+    }
+    case 'array': {
+      // 处理通用逻辑
+      // 对items处理（子表单处理，递归）
+      const item = unitedSchema.items
+      const type = typeCheck(item)
+      // 普通数组
+      if (type === 'Object') {
+        initParse({
+          unitedSchema: item as UnitedSchema,
+          idx: '$container',
+          parentType: 'array',
+          parentUiSchema: curUiSchema,
+          parentDataSchema: curDataSchema,
+          customProps,
+          typePath,
+          parentTypePath: curTypePath,
+          index: '$container',
+        })
+      } else if (type === 'Array') {
+        // 元祖
+        item?.map((childUnitedSchema: UnitedSchema, i: number) => {
+          initParse({
+            unitedSchema: childUnitedSchema,
+            idx: String(i),
+            parentType: 'tuple',
+            parentUiSchema: curUiSchema,
+            parentDataSchema: curDataSchema,
+            customProps,
+            typePath,
+            parentTypePath: curTypePath,
+            index: i,
+          })
+        })
+      }
+      break
+    }
+    default:
+      break
+  }
 }
 
 /**
@@ -280,63 +258,28 @@ const parseUnitedSchema = (
   uiSchema: UiSchema
   dataSchema: DataSchema
   typePath: Map
-  customProps?: any[]
+  customProps: string[]
 } => {
-  const dataSchema = {}
-  const uiSchema = {}
+  const dataSchema = {} as DataSchema
+  const uiSchema = {} as UiSchema
   // 用来存储每个表单项对应的type值，如果是嵌套格式，则解析为 { a: 'object', 'a.b': 'object', 'a.b.c': 'array' }
   const typePath = {}
   // $:的自定义属性，仅统计dataSchema的
-  const customProps: any[] = []
-  // 根元素的ui配置
-  const ui: Map = unitedSchema.ui || {}
-  // 处理全局schema配置
-  const firstLevelProps = handleFirstLevelCustomDataProps(
-    unitedSchema,
-    customProps
-  )
+  const customProps: string[] = []
 
-  for (const i in unitedSchema) {
-    if (
-      Object.prototype.hasOwnProperty.call(unitedSchema, i) &&
-      i.startsWith('ui:')
-    ) {
-      ui[i.slice(3)] = unitedSchema[i]
-    }
-  }
-
-  initParse(
+  initParse({
     unitedSchema,
-    dataSchema as DataSchema,
-    uiSchema as UiSchema,
-    typePath as Map,
-    '',
+    parentUiSchema: uiSchema,
+    parentDataSchema: dataSchema,
     customProps,
-    true
-  )
+    typePath,
+  })
 
   return {
-    dataSchema: {
-      validateTime: unitedSchema?.validateTime || 'submit',
-      requiredMode: unitedSchema?.requiredMode || 'default',
-      type: unitedSchema.type || 'object',
-      ...(unitedSchema?.title && { title: unitedSchema.title }),
-      ...(unitedSchema?.default && { default: unitedSchema.default }),
-      ...dataSchema,
-      ...firstLevelProps,
-    } as DataSchema,
-    uiSchema: {
-      ...(unitedSchema.formMode && { formMode: unitedSchema.formMode }),
-      ...(unitedSchema?.theme && { theme: unitedSchema?.theme }),
-      ...(!isEmpty(ui) && ui),
-      ...(unitedSchema.footer && { footer: unitedSchema.footer }),
-      ...(unitedSchema.containerStyle && {
-        containerStyle: unitedSchema.containerStyle,
-      }),
-      ...uiSchema,
-    },
+    dataSchema,
+    uiSchema,
     typePath,
-    ...(customProps.length > 0 && { customProps: [...new Set(customProps)] }),
+    customProps: [...new Set(customProps)],
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3558,6 +3558,11 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/lodash@^4.14.181":
+  version "4.14.181"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz#d1d3740c379fda17ab175165ba04e2d03389385d"
+  integrity sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==
+
 "@types/mdast@^3.0.0":
   version "3.0.10"
   resolved "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- parseUnitedSchema根元素透传dataSchema 关键字
- generator支持在components中配置组件的默认校验信息

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

packages/utils/__testsdata__

## Related PRs

N
