### PR TITLE
fix(theme): upload component cannot preview images after exportToString is enabled

### DIFF
--- a/packages/drip-form-theme-antd/src/UploaderField/newUpload.tsx
+++ b/packages/drip-form-theme-antd/src/UploaderField/newUpload.tsx
@@ -2,7 +2,7 @@
  * @Author: jiangxiaowei
  * @Date: 2022-01-10 17:11:29
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-01-28 18:20:14
+ * @Last Modified time: 2022-04-26 09:53:59
  */
 
 import React, { memo, FC, useMemo, useCallback } from 'react'
@@ -107,7 +107,7 @@ const UploaderField: FC<UploaderFieldProps> = ({
   ...restProps
 }) => {
   // 如果是string类型，则需要处理为对象形式
-  const newFieldData = useMemo(() => {
+  const newFieldData = useMemo<Array<UploadFile>>(() => {
     if (exportToString && typeof fieldData === 'string') {
       return [
         {
@@ -118,8 +118,18 @@ const UploaderField: FC<UploaderFieldProps> = ({
           url: fieldData,
         },
       ]
+    } else if (Array.isArray(fieldData)) {
+      return fieldData.map((item) => {
+        return {
+          name: '',
+          percent: 100,
+          status: 'done',
+          uid: '',
+          url: item,
+        }
+      })
     } else {
-      return fieldData || []
+      return []
     }
   }, [exportToString, fieldData])
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

修复antd主题上传组件，开启输出string之后（exportToString为true），多张图片无法预览问题

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N
