### PR TITLE
fix(generator): fixed the default width of the global ContainerStyle

### DIFF
--- a/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
+++ b/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
@@ -105,7 +105,7 @@ const PropertyConfig = () => {
           formData.containerStyle.width =
             formData.containerStyle.width ||
             generatorContext.current?.get().uiSchema?.containerStyle?.width ||
-            '100%'
+            (type != 'root' ? '100%' : 100)
         }
         // 标题特殊处理
         if (key === 'title') {
@@ -128,6 +128,7 @@ const PropertyConfig = () => {
     [
       dataSchema?.title,
       generatorContext,
+      type,
       uiSchema.footer,
       uiSchema?.showTitle,
       uiSchema.title,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

修复generator 全局布局宽度的默认值（默认一行一个）

修复前
![image](https://user-images.githubusercontent.com/19370610/166617212-ae4c1dcf-73ff-44db-9632-d75ae73dd65d.png)
修复后
![image](https://user-images.githubusercontent.com/19370610/166617226-ccadcfdc-cd69-4e17-86fb-62c4321aef7a.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N