### PR TITLE
feat(generator): support the same type for different themes

### DIFF
--- a/packages/drip-form/src/render/index.tsx
+++ b/packages/drip-form/src/render/index.tsx
@@ -3,7 +3,7 @@
  * @Author: jiangxiaowei
  * @Date: 2021-07-30 16:35:48
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-05-24 11:27:55
+ * @Last Modified time: 2022-05-26 16:29:38
  */
 import React from 'react'
 import { handleMargin } from '@jdfed/utils'
@@ -317,6 +317,7 @@ const Render = ({
             parentType,
             isFirst: !!isRoot && i === 0,
             uiProp,
+            theme: itemTheme,
           }
         )
       ) : (

--- a/packages/drip-form/src/render/type.ts
+++ b/packages/drip-form/src/render/type.ts
@@ -34,6 +34,7 @@ export type ContainerHoc = (
     // 是否是第一个表单
     isFirst: boolean
     uiProp: Record<string, any>
+    theme: string
   }
 ) => JSX.Element
 

--- a/packages/generator/src/components/GeneratorFormTheme/UiTypeChangeField/index.tsx
+++ b/packages/generator/src/components/GeneratorFormTheme/UiTypeChangeField/index.tsx
@@ -3,14 +3,14 @@
  * @Author: jiangxiaowei
  * @Date: 2022-05-19 10:22:53
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-05-19 14:46:15
+ * @Last Modified time: 2022-05-26 14:22:40
  */
 import React, { memo, FC, useCallback, useContext } from 'react'
 import { Select } from 'antd'
 import { CommonProps } from '../global'
 import { useSetRecoilState, useRecoilValue } from 'recoil'
 import {
-  curTypeAtom,
+  curThemeAndTypeAtom,
   GeneratorContext,
   selectedAtom,
   SelectOption,
@@ -25,7 +25,7 @@ const UiTypeChangeField: FC<CommonProps> = ({
   disabled,
   style,
 }) => {
-  const setType = useSetRecoilState(curTypeAtom)
+  const setThemeAndType = useSetRecoilState(curThemeAndTypeAtom)
   const generatorContext = useContext(GeneratorContext)
   const selectedFieldKey = useRecoilValue(selectedAtom)
 
@@ -99,9 +99,9 @@ const UiTypeChangeField: FC<CommonProps> = ({
         }
       )
       // 更新类型
-      setType(value)
+      setThemeAndType(value)
     },
-    [generatorContext, onReplace, options, selectedFieldKey, setType]
+    [generatorContext, onReplace, options, selectedFieldKey, setThemeAndType]
   )
 
   return (

--- a/packages/generator/src/components/LeftSideBar/index.tsx
+++ b/packages/generator/src/components/LeftSideBar/index.tsx
@@ -31,7 +31,6 @@ const LeftSideBar: React.FC = () => {
                         return (
                           category[key].fields[type] && (
                             <DragAtom
-                              // TODO @drag
                               key={JSON.stringify(
                                 category[key].fields[type].unitedSchema
                               )}

--- a/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
+++ b/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
@@ -1,8 +1,15 @@
 import React, { memo, useCallback, useEffect, useMemo } from 'react'
 import DripForm from '@jdfed/drip-form'
-import { typeCheck, deepClone, isEmpty, setDeepProp } from '@jdfed/utils'
+import {
+  typeCheck,
+  deepClone,
+  isEmpty,
+  setDeepProp,
+  getThemeAndType,
+} from '@jdfed/utils'
 import {
   curTypePropertyConfigSelector,
+  curThemeAndTypeAtom,
   curTypeAtom,
   propertyConfigSelector,
 } from '@generator/store'
@@ -12,7 +19,7 @@ import { produce } from 'immer'
 import { useRecoilState, useRecoilValue } from 'recoil'
 import generatorTheme from '@generator/components/GeneratorFormTheme'
 import type { SetType } from '@jdfed/hooks'
-import type { Map, UnitedSchema } from '@jdfed/utils'
+import type { Map, UnitedSchema, UiSchema } from '@jdfed/utils'
 
 const PropertyConfig = () => {
   const {
@@ -23,22 +30,26 @@ const PropertyConfig = () => {
     uiComponents,
     fieldKey,
   } = useRightSidebar()
-  // 当前选中的组件UI类型
-  const [type, setType] = useRecoilState(curTypeAtom)
+  // 当前选中的组件
+  const [themeAndType, setThemeAndType] = useRecoilState(curThemeAndTypeAtom)
+  // 当前选中的组件类型
+  const type = useRecoilValue(curTypeAtom)
   //当前类型的样式配置schema
   const curTypePropertyConfig = useRecoilValue(curTypePropertyConfigSelector)
   const propertyConfigOptions = useRecoilValue(propertyConfigSelector)
 
   useEffect(() => {
-    setType((uiSchema.type as string) || 'root')
-  }, [setType, uiSchema.type])
+    setThemeAndType(
+      uiSchema.type ? getThemeAndType(uiSchema as UiSchema) : 'root'
+    )
+  }, [setThemeAndType, uiSchema, uiSchema.type])
 
   /**
    * 初始化配置数据
    */
   const formData = useMemo(() => {
     return {
-      type,
+      type: themeAndType,
       $fieldKey: dataSchema.$fieldKey || fieldKey,
       title: uiSchema.title || {},
       containerStyle: uiSchema.containerStyle || {},
@@ -56,6 +67,7 @@ const PropertyConfig = () => {
       },
     }
   }, [
+    themeAndType,
     dataSchema.$fieldKey,
     dataSchema?.validateTime,
     dataSchema.default,

--- a/packages/generator/src/components/Viewport/DripFormDragHoc/index.tsx
+++ b/packages/generator/src/components/Viewport/DripFormDragHoc/index.tsx
@@ -3,7 +3,7 @@
  * @Author: jiangxiaowei
  * @Date: 2021-10-09 14:28:24
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-03-02 13:04:29
+ * @Last Modified time: 2022-05-26 14:24:08
  */
 import React, { memo, useCallback, useMemo, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -15,7 +15,7 @@ import {
   selectedAtom,
   closestEdgeAtom,
   allFieldAtom,
-  curTypeAtom,
+  curThemeAndTypeAtom,
   viewportConfigSelector,
   optionsAtom,
 } from '@generator/store'
@@ -34,6 +34,7 @@ type Props = {
   parentType: string
   parentMode: string
   isFirst: boolean
+  theme: string
 }
 
 // over对应边classname
@@ -54,6 +55,7 @@ const DripFormDragHoc: FC<Props> = memo(
     parentType,
     parentMode,
     isFirst,
+    theme,
   }) => {
     const [ref, setRef] = useState<HTMLElement | null>(null)
     const allField = useRecoilValue(allFieldAtom)
@@ -98,8 +100,11 @@ const DripFormDragHoc: FC<Props> = memo(
 
     // 当前选中的field
     const [selectedFieldKey, setSelectedFieldKey] = useRecoilState(selectedAtom)
-    const setCurType = useSetRecoilState(curTypeAtom)
-
+    const setThemeAndType = useSetRecoilState(curThemeAndTypeAtom)
+    // 当前拖拽的组件them::type类型
+    const curThemeAndType = useMemo(() => {
+      return type.split('::').length > 1 ? type : `${theme}::${type}`
+    }, [theme, type])
     /**
      * 选中field的事件
      */
@@ -107,9 +112,9 @@ const DripFormDragHoc: FC<Props> = memo(
       (e) => {
         e.stopPropagation()
         setSelectedFieldKey(fieldKey as string)
-        setCurType(type)
+        setThemeAndType(curThemeAndType)
       },
-      [fieldKey, setCurType, setSelectedFieldKey, type]
+      [curThemeAndType, fieldKey, setThemeAndType, setSelectedFieldKey]
     )
 
     useEffect(() => {
@@ -171,8 +176,8 @@ const DripFormDragHoc: FC<Props> = memo(
           createPortal(
             <DragOverlay>
               <DragItem
-                icon={allField[type].icon}
-                unitedSchema={allField[type].unitedSchema}
+                icon={allField[curThemeAndType].icon}
+                unitedSchema={allField[curThemeAndType].unitedSchema}
               />
             </DragOverlay>,
             document.body,

--- a/packages/generator/src/components/Viewport/index.tsx
+++ b/packages/generator/src/components/Viewport/index.tsx
@@ -27,7 +27,7 @@ import {
   DripFormUiComponetsAtom,
   draggingFieldKeyAtom,
   versionAtom,
-  curTypeAtom,
+  curThemeAndTypeAtom,
 } from '@generator/store'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { combine, deepClone } from '@jdfed/utils'
@@ -70,7 +70,7 @@ const Viewport = forwardRef<HTMLDivElement, Props>(
     const draggingFieldKey = useRecoilValue(draggingFieldKeyAtom)
     // 当前选中的表单项
     const setSelectedFieldKey = useSetRecoilState(selectedAtom)
-    const setCurType = useSetRecoilState(curTypeAtom)
+    const setThemeAndType = useSetRecoilState(curThemeAndTypeAtom)
     // 当前正在拖拽元素的schema
     const draggingFieldSchema = useMemo(() => {
       const schema: { data: Map | undefined; ui: Map | undefined } = {
@@ -98,6 +98,7 @@ const Viewport = forwardRef<HTMLDivElement, Props>(
           parentType,
           parentMode,
           isFirst,
+          theme,
         } = formItemProps
         return (
           <DripFormDragHoc
@@ -105,6 +106,7 @@ const Viewport = forwardRef<HTMLDivElement, Props>(
             fieldKey={currentFieldKey}
             containerStyle={containerStyle}
             type={type}
+            theme={theme}
             parentMode={parentMode}
             parentType={parentType}
             isFirst={isFirst}
@@ -176,8 +178,8 @@ const Viewport = forwardRef<HTMLDivElement, Props>(
 
     const clickFn = useCallback(() => {
       setSelectedFieldKey(null)
-      setCurType('root')
-    }, [setCurType, setSelectedFieldKey])
+      setThemeAndType('root')
+    }, [setThemeAndType, setSelectedFieldKey])
 
     return (
       <div className={styles.viewport} onClick={clickFn}>

--- a/packages/generator/src/hooks/useAddField.tsx
+++ b/packages/generator/src/hooks/useAddField.tsx
@@ -3,14 +3,15 @@
  * @Author: jiangxiaowei
  * @Date: 2021-10-08 10:20:13
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-05-09 10:14:55
+ * @Last Modified time: 2022-05-26 17:09:39
  */
 import { useCallback, useContext } from 'react'
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil'
+import { getThemeAndType } from '@jdfed/utils'
 import {
   selectedAtom,
   GeneratorContext,
-  curTypeAtom,
+  curThemeAndTypeAtom,
   optionsAtom,
 } from '@generator/store'
 import useDeleteField from './useDeleteField'
@@ -30,7 +31,7 @@ const useAddField = (): AddField => {
   const generatorContext = useContext(GeneratorContext)
   const { fieldKeyFn, addFieldLocation } = useRecoilValue(optionsAtom)
   const [selectedKey, setSelected] = useRecoilState(selectedAtom)
-  const setCurType = useSetRecoilState(curTypeAtom)
+  const setThemeAndType = useSetRecoilState(curThemeAndTypeAtom)
   const deleteField = useDeleteField(false)
   const canEdit = useCanEditJson()
   // unitedSchema最外层的order
@@ -170,7 +171,7 @@ const useAddField = (): AddField => {
           // 设置选中的表单
           setSelected(selectKey)
           // 设置选中的表单类型
-          setCurType(unitedSchema.ui.type)
+          setThemeAndType(getThemeAndType(unitedSchema.ui))
         },
       })
       // // viewport区域拖拽且非排序模式，需要删除原来位置的表单
@@ -186,7 +187,7 @@ const useAddField = (): AddField => {
       generatorContext,
       lastFieldKey,
       selectedKey,
-      setCurType,
+      setThemeAndType,
       setSelected,
     ]
   )

--- a/packages/generator/src/store/leftSidebar/index.ts
+++ b/packages/generator/src/store/leftSidebar/index.ts
@@ -1,4 +1,5 @@
 import { atom, selector } from 'recoil'
+import { getThemeAndType } from '@jdfed/utils'
 import { containerConfig, antdConfig } from '@generator/fields'
 import type {
   FieldItemMap,
@@ -39,15 +40,21 @@ export const sidebarDataAtom = atom<ComponentsData>({
   },
 })
 
-// TODO @jiangxiaowei2 主题绑定 左侧所有表单
+// 左侧所有表单
 export const allFieldAtom = selector<FieldItemMap>({
   key: 'allfield',
   get: ({ get }) => {
     const { category } = get(sidebarDataAtom)
-    let allField = {}
-    for (const i in category) {
-      allField = { ...allField, ...category[i].fields }
-    }
+    const allField: FieldItemMap = {}
+    Object.values(category).map(({ fields }) => {
+      Object.values(fields).map((field) => {
+        const { unitedSchema } = field
+        const { ui } = unitedSchema
+        if (ui) {
+          allField[getThemeAndType(ui)] = field
+        }
+      })
+    })
     return allField
   },
 })

--- a/packages/generator/src/store/rightSidebar/index.ts
+++ b/packages/generator/src/store/rightSidebar/index.ts
@@ -1,6 +1,7 @@
 import { selector } from 'recoil'
+import { getThemeAndType } from '@jdfed/utils'
 import { sidebarDataAtom, uiTypeOptionsAtom } from '../leftSidebar'
-import { curTypeAtom } from '../unclassified'
+import { curThemeAndTypeAtom } from '../unclassified'
 import { baseMap } from '@generator/fields'
 import rootConfig from '@generator/fields/container/root.field'
 import type { UnitedSchema } from '@jdfed/utils'
@@ -11,16 +12,17 @@ export const allPropertyConfigSchemaSelector = selector<
 >({
   key: 'propertyConfigSchema',
   get: ({ get }) => {
-    const { category, order } = get(sidebarDataAtom)
+    const { category } = get(sidebarDataAtom)
     const uiTypeOptions = get(uiTypeOptionsAtom)
     const allPropertyConfig: Record<string, UnitedSchema['schema']> = {
       root: rootConfig,
     }
-    order.map((key) => {
-      Object.keys(category[key].fields).map((id) => {
-        const field = category[key].fields[id]
-        if (id != 'root') {
-          const propertyConfig =
+    Object.values(category).map(({ fields }) => {
+      Object.values(fields).map((field) => {
+        const { unitedSchema } = field
+        const { ui } = unitedSchema
+        if (ui) {
+          allPropertyConfig[getThemeAndType(ui)] =
             field?.propertyConfig?.schema ||
             ([
               {
@@ -84,7 +86,6 @@ export const allPropertyConfigSchemaSelector = selector<
                   field?.propertyConfig?.styleSchema || field?.styleSchema,
               },
             ] as UnitedSchema['schema'])
-          allPropertyConfig[id] = propertyConfig
         }
       })
     })
@@ -96,7 +97,7 @@ export const allPropertyConfigSchemaSelector = selector<
 export const curTypePropertyConfigSelector = selector<UnitedSchema['schema']>({
   key: 'curTypePropertyConfig',
   get: ({ get }) => {
-    const curType = get(curTypeAtom)
-    return get(allPropertyConfigSchemaSelector)[curType]
+    const curThemeAndType = get(curThemeAndTypeAtom)
+    return get(allPropertyConfigSchemaSelector)[curThemeAndType]
   },
 })

--- a/packages/generator/src/store/unclassified/index.ts
+++ b/packages/generator/src/store/unclassified/index.ts
@@ -1,5 +1,5 @@
 import React, { MutableRefObject } from 'react'
-import { atom } from 'recoil'
+import { atom, selector } from 'recoil'
 import { UnitedSchema } from '@jdfed/utils'
 import antd from '@jdfed/drip-form-theme-antd'
 import type { DripFormRefType, UiComponents } from '@jdfed/drip-form'
@@ -87,11 +87,23 @@ export const versionAtom = atom<number>({
 })
 
 /**
- * 当前选中的表单类型
+ * 当前选中的表单主题::控件类型
+ * 未选中任何表单 为 root
+ * 选中表单 为 theme::type
  */
-export const curTypeAtom = atom<string>({
-  key: 'curType',
+export const curThemeAndTypeAtom = atom<string>({
+  key: 'curThemeAndType',
   default: 'root',
+})
+
+//当前选中的表单控件类型
+export const curTypeAtom = selector<string>({
+  key: 'curType',
+  get: ({ get }) => {
+    const themeAndType = get(curThemeAndTypeAtom)
+    const [theme, type] = themeAndType.split('::')
+    return type || theme
+  },
 })
 
 /**

--- a/packages/utils/src/common/index.ts
+++ b/packages/utils/src/common/index.ts
@@ -3,7 +3,7 @@ import { CSSProperties } from 'react'
  * @Author: jiangxiaowei
  * @Date: 2020-05-30 15:05:13
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-05-24 13:41:16
+ * @Last Modified time: 2022-05-26 17:01:05
  */
 import type { TreeItems, TreeItem } from '../tree/types'
 import type { Map } from './type'
@@ -421,4 +421,20 @@ export const handleMargin = (style: CSSProperties): void => {
     }
     style.width = `calc(${style.width} - ${marginRight} - ${marginLeft})`
   }
+}
+
+/**
+ * 根据uiSchema，获取当前schem相对的主题和组件类型
+ * @param uiSchema
+ * @returns
+ */
+export const getThemeAndType = (
+  uiSchema: {
+    type: string
+    theme?: string
+  } & Map
+): string => {
+  const { type, theme } = uiSchema
+  const [, newType] = type.split('::')
+  return newType ? type : `${theme}::${type}`
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

form-generator现在组件的配置是按照type分类的，如下：
```
{
  //未选中任何表单的全局配置
  root:{},
  //输入框的配置
  text:{},
}
```
以上按照type分类，存在以下问题：
1. 主题不一致，但是type相同。配置会覆盖
2. 相同type，默认配置不一样的场景

### 考虑过的方案
* 方案一
   用户配置的时候，保证type是唯一的。使用`theme:type`进行区分。
   **缺点：**
   * 用户开发自定义主题存在心智负担
* 方案二
   ```
   {
     theme:{
       type:xxx     
      }
   }
   ```
    **缺点：**
   * 无法解决问题2
* 方案三
   generator自动根据组件生成唯一值
   **缺点：**
   * 侵入性：唯一值需要和组件的主题和组件类型进行绑定，所以需要修改表单协议
   * 该协议不通用，只能在特定的generator下使用

调研后，使用配置不一样的表单的场景比较少见且用户可以通过配置新的主题或组件来解决该问题。所以最终采用方案二
## Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N
