### PR TITLE
fix(generator): compatibility with old data

### DIFF
--- a/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
+++ b/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
@@ -38,10 +38,18 @@ const PropertyConfig = () => {
   const propertyConfigOptions = useRecoilValue(propertyConfigSelector)
 
   useEffect(() => {
+    const globalTheme = generatorContext.current?.get('').uiSchema.theme
     setThemeAndType(
-      uiSchema.type ? getThemeAndType(uiSchema as UiSchema) : 'root'
+      uiSchema.type
+        ? getThemeAndType({
+            ...(!['object', 'array'].includes(uiSchema.type as string) && {
+              theme: globalTheme,
+            }),
+            ...uiSchema,
+          } as UiSchema)
+        : 'root'
     )
-  }, [setThemeAndType, uiSchema, uiSchema.type])
+  }, [generatorContext, setThemeAndType, uiSchema, uiSchema.type])
 
   /**
    * 初始化配置数据


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

修复 #211 导致旧数据，右侧属性配置面板不展示问题
* #211 支持不同主题的相同type类型，避免用户不同主题下，type重复导致的覆盖问题。
* #211 之后，属性配置使用theme:type查找当前组件的属性配置信息。旧数据未配置theme,会查找undefined:type,而新的组件区若配置了theme，则会导致两边不匹配，查找不到当前组件的配置信息

解决方案：
当用户未配置主题时且组件类型非对象容器和数组容器时，属性配置面板会兜底使用globalTheme:type 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

#211
