### PR TITLE
fix(form): when collapse is folded, tooltip does not show

### DIFF
--- a/packages/drip-form/src/container/ObjectContainer/index.tsx
+++ b/packages/drip-form/src/container/ObjectContainer/index.tsx
@@ -3,10 +3,11 @@
  * @Author: jiangxiaowei
  * @Date: 2021-08-11 15:26:55
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-06-15 14:53:37
+ * @Last Modified time: 2022-06-23 15:22:54
  */
-import React, { useMemo, memo } from 'react'
+import React, { useMemo, memo, useEffect } from 'react'
 import { useTitle } from '@jdfed/hooks'
+import ReactTooltip from 'react-tooltip'
 import renderCoreFn from '../../render'
 import { Title, CommonContainerHoc } from '@form/components/index'
 import cx from 'classnames'
@@ -105,6 +106,10 @@ const objectContainer = memo<Props & RenderFnProps & ObjectContainerProps>(
       // 用户配置了active||generator viewport区域需要展开折叠面板
       return formMode === 'generator' || active ? [curKey] : []
     }, [formMode, curKey, active])
+
+    useEffect(() => {
+      ReactTooltip.rebuild()
+    })
 
     return (
       <>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

```
{
  "type": "object",
  "validateTime": "change",
  "ui": {},
  "theme": "antd",
  "schema": [
    {
      "type": "object",
      "title": "对象容器",
      "ui": {
        "type": "object",
        "mode": "collapse",
        "$:dripStyle": true,
        "ghost": true,
        "containerStyle": {
          "padding": 0,
          "marginBottom": 5
        },
        "active": false,
        "title": {
          "verticalAlign": "top"
        }
      },
      "schema": [
        {
          "type": "string",
          "title": "自定义组件",
          "$:customFirstLevelProp": "位于顶层的自定义组件属性",
          "ui": {
            "type": "custom",
            "description": {
              "title": "111",
              "type": "icon",
              "trigger": "hover"
            },
            "theme": "custom"
          },
          "fieldKey": "custom_0hi99X"
        }
      ],
      "fieldKey": "object_tc6mNS"
    }
  ]
}
```
修复 对象容器为折叠模式且默认不展开时，提示组件不展示的问题
问题参考：[react-tooltip](https://github.com/wwayne/react-tooltip#3-tooltip-not-binding-to-dynamic-content)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N
