### PR TITLE
fix(generator): when the theme is not set, the property configuration will not be displayed

### DIFF
--- a/packages/generator/src/store/unclassified/index.ts
+++ b/packages/generator/src/store/unclassified/index.ts
@@ -117,14 +117,23 @@ export const curThemeAndTypeAtom = selector<string>({
   get: ({ get }) => {
     return get(themeAndTypeAtom)
   },
-  set: ({ set }, newValue) => {
+  set: ({ set, get }, newValue) => {
     if (newValue instanceof DefaultValue) {
       set(themeAndTypeAtom, newValue)
     } else {
       // 如果用户输入的theme::type中type是root、object、array。则默认设置为root、object、array。v0不建议用户使用object、array、root的类型。文档体现
-      const [, type] = newValue.split('::')
-      if (type && ['root', 'array', 'object'].includes(type)) {
-        set(themeAndTypeAtom, type)
+      const [theme, type] = newValue.split('::')
+      if (type) {
+        if (['root', 'array', 'object'].includes(type)) {
+          // 选中全局、非对象容器、非数组容器
+          set(themeAndTypeAtom, type)
+        } else if (theme === 'undefined') {
+          // 未设置theme，使用全局主题
+          const globalTheme = get(globalThemeAtom)
+          set(themeAndTypeAtom, `${globalTheme}::${type}`)
+        } else {
+          set(themeAndTypeAtom, newValue)
+        }
       } else {
         set(themeAndTypeAtom, newValue)
       }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

修复以下schema，不展示属性配置的bug
```
{
  "type": "object",
  "validateTime": "change",
  "ui": {},
  "theme": "antd",
  "schema": [
    {
      "type": "string",
      "title": "输入框",
      "ui": {
        "type": "text",
        "style": {
          "width": "100%"
        }
      },
      "fieldKey": "text_vTNSKq"
    }
  ]
}
```
![image](https://user-images.githubusercontent.com/19370610/176587379-570d31f7-2dd0-4b51-a176-4dbb3be0ade1.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

![image](https://user-images.githubusercontent.com/19370610/176587417-5b8a809a-2982-4fb1-93ad-e86b323d0c71.png)

## Related PRs

N
