### PR TITLE
fix: inaccurate width calculation when margin contains extra spaces

### DIFF
--- a/packages/generator/src/fields/common/propertyConfig/layout.schema.ts
+++ b/packages/generator/src/fields/common/propertyConfig/layout.schema.ts
@@ -28,6 +28,7 @@ const unitedSchema = {
       fieldKey: 'margin',
       type: 'string',
       title: '组件外边距',
+      transform: ['trim'],
       ui: {
         type: 'text',
         placeholder: '形如0 30px 20px 0 | 0 30px',
@@ -37,6 +38,7 @@ const unitedSchema = {
       fieldKey: 'padding',
       type: 'string',
       title: '组件内边距',
+      transform: ['trim'],
       ui: {
         type: 'text',
         placeholder: '形如0 10px 0 10px | 0 10px',

--- a/packages/generator/src/fields/container/root.field.ts
+++ b/packages/generator/src/fields/container/root.field.ts
@@ -229,6 +229,7 @@ const unitedSchema = [
         fieldKey: 'margin',
         type: 'string',
         title: '标题外边距',
+        transform: ['trim'],
         ui: {
           type: 'text',
           disabled: false,
@@ -290,6 +291,7 @@ const unitedSchema = [
         fieldKey: 'margin',
         type: 'string',
         title: '组件外边距',
+        transform: ['trim'],
         ui: {
           type: 'text',
           placeholder: '形如0 30px 20px 0 | 0 30px',
@@ -299,6 +301,7 @@ const unitedSchema = [
         fieldKey: 'padding',
         type: 'string',
         title: '组件内边距',
+        transform: ['trim'],
         ui: {
           type: 'text',
           placeholder: '形如0 10px 0 10px | 0 10px',

--- a/packages/utils/src/common/index.ts
+++ b/packages/utils/src/common/index.ts
@@ -3,7 +3,7 @@ import { CSSProperties } from 'react'
  * @Author: jiangxiaowei
  * @Date: 2020-05-30 15:05:13
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-06-23 17:53:28
+ * @Last Modified time: 2022-07-14 13:25:05
  */
 import type { TreeItems, TreeItem } from '../tree/types'
 import type { Map } from './type'
@@ -408,7 +408,7 @@ export const handleMargin = (style: CSSProperties): void => {
   if (width) {
     if (margin) {
       if (typeof margin === 'string') {
-        const marginArr = margin.split(' ')
+        const marginArr = margin.trim().split(' ')
         if (marginArr.length === 1) {
           marginRight = margin
           marginLeft = margin


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

修复containerStyle.margin字段多余空格，导致宽度计算不准确的问题
```
 "containerStyle": {
      "margin": "0 16px 0 0 "
    }
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N
