### PR TITLE
fix(form): vcontrol causes component flickering

### DIFF
--- a/packages/drip-form/src/DripForm/index.tsx
+++ b/packages/drip-form/src/DripForm/index.tsx
@@ -2,7 +2,7 @@
  * @Author: jiangxiaowei
  * @Date: 2020-05-14 16:54:32
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-04-18 17:30:53
+ * @Last Modified time: 2022-08-14 08:56:37
  */
 import React, {
   forwardRef,
@@ -152,8 +152,6 @@ const DripForm = forwardRef<DripFormRefType, DripFormRenderProps>(
             ajv,
             customProps,
           }).formData || {},
-        // ajv是否已经将dataSchema中的默认值添加到formData中
-        hasDefault: false,
         // 下个版本废弃，改用ajvErros和customErrors
         errors: {},
         customErrors: {},
@@ -228,7 +226,6 @@ const DripForm = forwardRef<DripFormRefType, DripFormRenderProps>(
       ajvErrors,
       customErrors,
       checking,
-      hasDefault,
       visibleFieldKey,
       changeKey,
       arrayKey,
@@ -475,7 +472,6 @@ const DripForm = forwardRef<DripFormRefType, DripFormRenderProps>(
         <FormDataContext.Provider value={formDataContextState}>
           <div className={'drip-form-root'}>
             {renderCoreFn({
-              hasDefault,
               uiComponents,
               dataSchema,
               uiSchema,

--- a/packages/drip-form/src/container/ArrayContainer/SortableItem.tsx
+++ b/packages/drip-form/src/container/ArrayContainer/SortableItem.tsx
@@ -31,7 +31,6 @@ const SortableItem: FC<
     uiComponents,
     dispatch,
     fieldData = [],
-    hasDefault,
     dataSchema,
     uiSchema,
     errors,
@@ -133,7 +132,6 @@ const SortableItem: FC<
         </div>
         <div className="array-item--case">
           {renderCoreFn({
-            hasDefault,
             uiComponents,
             dataSchema,
             uiSchema,

--- a/packages/drip-form/src/container/ObjectContainer/index.tsx
+++ b/packages/drip-form/src/container/ObjectContainer/index.tsx
@@ -3,7 +3,7 @@
  * @Author: jiangxiaowei
  * @Date: 2021-08-11 15:26:55
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-06-23 15:22:54
+ * @Last Modified time: 2022-08-14 08:56:53
  */
 import React, { useMemo, memo, useEffect } from 'react'
 import { useTitle } from '@jdfed/hooks'
@@ -42,7 +42,6 @@ const objectContainer = memo<Props & RenderFnProps & ObjectContainerProps>(
     customComponents,
     uiComponents,
     dispatch,
-    hasDefault,
     dataSchema,
     uiSchema,
     errors,
@@ -144,7 +143,6 @@ const objectContainer = memo<Props & RenderFnProps & ObjectContainerProps>(
               {...panelProp}
             >
               {renderCoreFn({
-                hasDefault,
                 uiComponents,
                 dataSchema,
                 uiSchema,
@@ -172,7 +170,6 @@ const objectContainer = memo<Props & RenderFnProps & ObjectContainerProps>(
             })}
           >
             {renderCoreFn({
-              hasDefault,
               uiComponents,
               dataSchema,
               uiSchema,

--- a/packages/drip-form/src/reducers/index.ts
+++ b/packages/drip-form/src/reducers/index.ts
@@ -2,7 +2,7 @@
  * @Author: jiangxiaowei
  * @Date: 2020-05-14 15:43:02
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-05-17 18:12:55
+ * @Last Modified time: 2022-08-14 08:55:35
  */
 import { createContext } from 'react'
 import {
@@ -342,10 +342,6 @@ const formDataReducer = (state: State, action: Action): void => {
           (item) => !deleteKeys?.includes(item)
         )
       }
-      break
-    }
-    case 'setDefaultSuccess': {
-      state.hasDefault = action.action.hasDefault
       break
     }
     case 'setArrayKey': {

--- a/packages/drip-form/src/render/index.tsx
+++ b/packages/drip-form/src/render/index.tsx
@@ -3,7 +3,7 @@
  * @Author: jiangxiaowei
  * @Date: 2021-07-30 16:35:48
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-05-26 16:29:38
+ * @Last Modified time: 2022-08-14 09:32:35
  */
 import React from 'react'
 import { handleMargin } from '@jdfed/utils'
@@ -12,7 +12,6 @@ import type { Map, Theme } from '@jdfed/utils'
 
 /*TODO 优化renderprops和container编写 区分component prop和container prop*/
 const Render = ({
-  hasDefault,
   uiComponents,
   dataSchema,
   uiSchema,
@@ -178,10 +177,9 @@ const Render = ({
     const description = uiProp.description || null
     // Field控制函数体
     const vcontrol = properties[item].vcontrol
-    const vcontrolDefault = properties[item].vcontrolDefault
     let controlFuc
     // 是否展示当前Field
-    let isShow = vcontrolDefault || false
+    let isShow = false
     // 解析联动控制函数函数体
     if (vcontrol) {
       try {
@@ -190,23 +188,15 @@ const Render = ({
         } else {
           controlFuc = new Function('props', vcontrol as string)
         }
-        //
-        /* TODO 优化初始化是否渲染逻辑
-         * 添加全局key用来判断当前表单是否渲染函数已经调用完成；需等待所有是否渲染逻辑调用完成之后，再展示所有表单
-         * 当前实现是使用vcontroalDefault:boolean 来控制默认展示还是隐藏
-         */
-        // ajv已经将dataSchema中默认值添加到formData中，避免bug（fix: 组件渲染和formData生成的顺序问题以及checkbox全不选时的默认值问题 #C2020092276661）
-        if (hasDefault) {
-          isShow = controlFuc({
-            formData,
-            uiSchema,
-            dataSchema,
-            get,
-            getKey,
-            fieldKey: currentFieldKey,
-            fieldData,
-          })
-        }
+        isShow = controlFuc({
+          formData,
+          uiSchema,
+          dataSchema,
+          get,
+          getKey,
+          fieldKey: currentFieldKey,
+          fieldData,
+        })
       } catch (error) {
         console.error(`${item}：vcontrol函数体错误，请确认`)
         console.error(error)
@@ -229,8 +219,6 @@ const Render = ({
     // 非FieldContaienr基础容器均需要透传，并且render函数也需要传递
     const render = {
       containerHoc,
-      // 是否已经将dataSchema中default设置到formData中
-      hasDefault,
       // 全局dataSchema
       dataSchema,
       // 全局uiSchema

--- a/packages/drip-form/src/render/type.ts
+++ b/packages/drip-form/src/render/type.ts
@@ -39,8 +39,6 @@ export type ContainerHoc = (
 ) => JSX.Element
 
 export type RenderFnProps = {
-  // ajv是否已经设置了默认值
-  hasDefault: boolean
   dataSchema: DataSchema
   uiSchema: UiSchema
   // 错误信息

--- a/packages/hooks/src/useValidate.ts
+++ b/packages/hooks/src/useValidate.ts
@@ -71,12 +71,6 @@ const useValidate = (validate: Validate): ((arg0: Params) => void) => {
         type: 'setChecking',
         checking: false,
       })
-      dispatch({
-        type: 'setDefaultSuccess',
-        action: {
-          hasDefault: true,
-        },
-      })
     },
     { wait: 500 }
   )

--- a/packages/utils/src/type.ts
+++ b/packages/utils/src/type.ts
@@ -33,8 +33,6 @@ export type State = {
   customErrors: Record<string, string>
   // 是否正在校验
   checking: boolean
-  // ajv是否已经将dataSchema中的默认值添加到formData中
-  hasDefault: boolean
   // 当前可见的表单
   visibleFieldKey: Array<string>
   // 当前正在变动的表单
@@ -199,13 +197,6 @@ type SetVisibleKeyAction = {
   }
 }
 
-type SetDefaultSuccessAction = {
-  type: 'setDefaultSuccess'
-  action: {
-    hasDefault: boolean
-  }
-}
-
 // 数组容器设置映射的组件唯一key（避免删除导致的组件渲染问题）
 type SetArrayKey = {
   type: 'setArrayKey'
@@ -240,5 +231,4 @@ export type Action =
   | DeleteErrorAction
   | SetCheckingAction
   | SetVisibleKeyAction
-  | SetDefaultSuccessAction
   | SetArrayKey


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

设置vcontrol，导致组件闪烁
![Jietu20220814-100259-HD](https://user-images.githubusercontent.com/19370610/184519481-3e7ee972-b630-4ed1-95bc-79b5682fc800.gif)

```
{
  "type": "object",
  "validateTime": "change",
  "ui": {},
  "theme": "antd",
  "schema": [
    {
      "type": "string",
      "title": "输入框",
      "ui": {
        "type": "text",
        "style": {
          "width": "100%"
        },
        "theme": "antd",
        "vcontrol": "return props.formData.radio_Q0G1FT==='1'"
      },
      "fieldKey": "text_eYyRzb"
    },
    {
      "type": "string",
      "title": "单选",
      "default": "1",
      "ui": {
        "type": "radio",
        "theme": "antd",
        "vcontrol": "return props.formData.checkbox1.includes('0')",
        "options": [
          {
            "label": "是",
            "value": "1"
          },
          {
            "label": "否",
            "value": "0"
          }
        ]
      },
      "fieldKey": "radio_Q0G1FT"
    },
    {
      "type": "array",
      "title": "多选框",
      "default": [],
      "ui": {
        "type": "checkbox",
        "theme": "antd",
        "options": [
          {
            "label": "0",
            "value": "0"
          },
          {
            "label": "1",
            "value": "1"
          }
        ]
      },
      "fieldKey": "checkbox1"
    }
  ]
}
```

### why
原因是 之前为了修复以下问题添加了vcontorlDefault导致。
> 当我为某`checkbox1`设置default为`[]`，并将另一组件`xxx`设置为由`checkbox1`的选中值控制显示和隐藏时(`"vcontrol": "return formData.checkbox1.includes('0')"`)，初始化渲染以及全不选时，会报错`TypeError: Cannot read property 'includes' of undefined`

### 如何解决`TypeError: Cannot read property 'includes' of undefined`
针对`TypeError: Cannot read property 'includes' of undefined`问题，有以下两个解决方案：
1. 判断formData.checkbox1存在再include 
2. 后续将添加校验添加默认值前置到init阶段。

方案2一开始没有支持；

方案1不是很优雅，需要用户判断

所以drip-form内部添加了`hasDefault`来判断ajv校验是否完毕（ajv是否已经将default字段设置到formData中），确保不会设置了default仍然提示`TypeError: Cannot read property 'includes' of undefined`。但该方案需要添加vcontrolDefault来设置组件的默认展示状态（设置了`vcontrol`，组件默认是不渲染的）。在ajv还没有生成默认数据时，组件默认是否渲染使用`vcontrolDefault`。ajv生成默认数据后，组件渲染使用`vcontrol`逻辑判断。

### 总结
以上内部的`hadDefault`和`vcontrolDefault`导致了设置vcontrol，组件闪烁的问题。

最终解决方案是使用方案2，既可以避免`TypeError: Cannot read property 'includes' of undefined`，也可以避免组件闪烁问题。

由于方案2在 #81 已经支持，所以可以删除内部的`hasDefault`。用户也无需设置`vcontrolDefaul`字段（设置了会忽略该字段，以`vcontrol`逻辑为准）。

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan
![Jietu20220814-100453-HD](https://user-images.githubusercontent.com/19370610/184519512-30d8c15f-dfc8-460d-9ce9-ed79702351e5.gif)



## Related PRs

#81
