### PR TITLE
fix(generator): verification configuration is not initialized correctly when switching components

### DIFF
--- a/packages/generator/src/components/RightSideBar/Check/index.tsx
+++ b/packages/generator/src/components/RightSideBar/Check/index.tsx
@@ -4,7 +4,7 @@
  * @Author: jiangxiaowei
  * @Date: 2021-08-16 11:32:22
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-06-10 13:39:58
+ * @Last Modified time: 2022-08-16 14:32:57
  */
 import React, { useMemo, memo, useCallback } from 'react'
 import {
@@ -32,15 +32,17 @@ const CheckConfig = (): JSX.Element => {
   // 通用关键字(包含的关键字被转换为formData.common)
   const commonKeywords = useMemo(() => new Set(), [])
 
-  // 业务关键字错误文案配置schema
+  // 业务关键字错误文案配置schema(表单切换，需要重置)
   const businessErrTipSchema = useMemo<Array<Record<string, unknown>>>(
     () => [],
-    []
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedFieldKey]
   )
-  // 通用关键字错误文案配置schema
+  // 通用关键字错误文案配置schema(表单切换，需要重置)
   const commonErrTipSchema = useMemo<Array<Record<string, unknown>>>(
     () => [],
-    []
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedFieldKey]
   )
 
   // 当前数据类型的校验配置（通用+业务）


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

切换组件时，必填错误文案配置丢失，变成指定必填项。
![image](https://user-images.githubusercontent.com/19370610/184814893-53caf9d7-b5db-41db-bf2d-22b09479c52c.png)


### why
错误文案配置（commonErrTipSchema）是一个数组。在viewport区域切换组件时，commonErrTipSchema未重置

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N
