### PR TITLE
feat: add queryConfig & fetchAPI to query data

### DIFF
--- a/examples/form-generator/package.json
+++ b/examples/form-generator/package.json
@@ -1,24 +1,28 @@
 {
-	"name": "form-generator",
-	"version": "0.1.0",
-	"author": "JDFED",
-	"private": true,
-	"scripts": {
-		"dev": "vite",
-		"build:generator": "vite build",
-		"serve": "vite preview"
-	},
-	"dependencies": {
-		"@jdfed/drip-form": "*",
-		"@jdfed/drip-form-theme-antd": "*",
-		"@jdfed/form-generator": "*",
-		"@jdfed/utils": "*",
-		"react": "^17.0.0",
-		"react-dom": "^17.0.0",
-		"recoil": "^0.4.0"
-	},
-	"devDependencies": {
-		"@vitejs/plugin-react-refresh": "^1.3.1",
-		"vite": "^2.4.4"
-	}
+  "name": "form-generator",
+  "version": "0.1.0",
+  "author": "JDFED",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build:generator": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@jdfed/drip-form": "*",
+    "@jdfed/drip-form-theme-antd": "*",
+    "@jdfed/form-generator": "*",
+    "@jdfed/utils": "*",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
+    "recoil": "^0.4.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react-refresh": "^1.3.1",
+    "msw": "^0.49.0",
+    "vite": "^2.4.4"
+  },
+  "msw": {
+    "workerDirectory": "public"
+  }
 }

--- a/examples/form-generator/public/mockServiceWorker.js
+++ b/examples/form-generator/public/mockServiceWorker.js
@@ -1,0 +1,303 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (0.49.0).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = '3d6b9f06410d179a7f7404d4bf4c3c70'
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: INTEGRITY_CHECKSUM,
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
+
+  // Bypass server-sent events.
+  if (accept.includes('text/event-stream')) {
+    return
+  }
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = Math.random().toString(16).slice(2)
+
+  event.respondWith(
+    handleRequest(event, requestId).catch((error) => {
+      if (error.name === 'NetworkError') {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url
+        )
+        return
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
+      console.error(
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+        request.method,
+        request.url,
+        `${error.name}: ${error.message}`
+      )
+    })
+  )
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: Object.fromEntries(clonedResponse.headers.entries()),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const clonedRequest = request.clone()
+
+  function passthrough() {
+    // Clone the request because it might've been already used
+    // (i.e. its body has been read and sent to the client).
+    const headers = Object.fromEntries(clonedRequest.headers.entries())
+
+    // Remove MSW-specific request headers so the bypassed requests
+    // comply with the server's CORS preflight check.
+    // Operate with the headers as an object because request "Headers"
+    // are immutable.
+    delete headers['x-msw-bypass']
+
+    return fetch(clonedRequest, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Bypass requests with the explicit bypass header.
+  // Such requests can be issued by "ctx.fetch()".
+  if (request.headers.get('x-msw-bypass') === 'true') {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body: await request.text(),
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return passthrough()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.data
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a "respondWith" promise emulates a network error.
+      throw networkError
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [channel.port2])
+  })
+}
+
+function sleep(timeMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeMs)
+  })
+}
+
+async function respondWithMock(response) {
+  await sleep(response.delay)
+  return new Response(response.body, response)
+}

--- a/examples/form-generator/src/App/schema.js
+++ b/examples/form-generator/src/App/schema.js
@@ -1,6 +1,150 @@
 export default {
-  validateTime: 'change',
   type: 'object',
-  ui: {},
+  validateTime: 'change',
+  ui: {
+    title: {
+      width: 82,
+      placement: 'left',
+    },
+    flow: {
+      version: '0.1.0',
+      trigger: {
+        event: 'globalChange',
+      },
+      actions: [
+        {
+          type: 'controlFlow',
+          condintion: [
+            {
+              fieldKey1: 'a data',
+              operator: '===',
+              value2: '0',
+              logicOperator: '&&',
+            },
+          ],
+          effect: [
+            {
+              type: 'set',
+              fieldKey: 'select_kps22V uiSchema queryConfig.refreshId',
+              value: '',
+            },
+            {
+              type: 'set',
+              fieldKey: 'select_hyScBs uiSchema queryConfig.refreshId',
+              value: '',
+            },
+          ],
+        },
+      ],
+    },
+  },
   theme: 'antd',
+  schema: [
+    {
+      type: 'string',
+      title: '单选',
+      default: '1',
+      ui: {
+        type: 'radio',
+        theme: 'antd',
+        options: [
+          {
+            label: '是',
+            value: '1',
+          },
+          {
+            label: '否',
+            value: '0',
+          },
+        ],
+      },
+      fieldKey: 'a',
+    },
+    {
+      type: 'string',
+      title: '输入框',
+      ui: {
+        type: 'text',
+        style: {
+          width: '100%',
+        },
+        theme: 'antd',
+      },
+      fieldKey: 'text_lkXQ-Y',
+    },
+    {
+      type: 'string',
+      title: 'get选择器',
+      ui: {
+        type: 'select',
+        theme: 'antd',
+        style: {
+          width: 120,
+        },
+        queryConfig: {
+          optionsType: '0',
+          url: 'http://localhost:2002/getSelectOptions',
+          params: [
+            {
+              key: '1',
+              value: '1',
+            },
+          ],
+        },
+        options: [
+          {
+            label: '1',
+            value: '1',
+          },
+        ],
+      },
+      fieldKey: 'select_kps22V',
+    },
+    {
+      type: 'string',
+      title: 'post选择器',
+      ui: {
+        type: 'select',
+        theme: 'antd',
+        style: {
+          width: 120,
+        },
+        queryConfig: {
+          optionsType: '0',
+          url: 'http://localhost:2002/postSelectOptions',
+          method: 'POST',
+          dataPath: 'data',
+        },
+        options: [
+          {
+            label: '1',
+            value: '1',
+          },
+        ],
+      },
+      fieldKey: 'select_hyScBs',
+    },
+    {
+      type: ['string', 'number', 'array'],
+      title: '选择器',
+      ui: {
+        type: 'select',
+        theme: 'antd',
+        style: {
+          width: 120,
+        },
+        queryConfig: {
+          optionsType: '1',
+          options: [
+            {
+              label: '1',
+              value: '1',
+            },
+          ],
+          setPath: 'options',
+        },
+      },
+      fieldKey: 'select_RB14Wj',
+    },
+  ],
 }

--- a/examples/form-generator/src/main.jsx
+++ b/examples/form-generator/src/main.jsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
+import { worker } from './mocks/browser'
+if (process.env.NODE_ENV === 'development') {
+  worker.start()
+}
 
 ReactDOM.render(
   <React.StrictMode>

--- a/examples/form-generator/src/mocks/browser.js
+++ b/examples/form-generator/src/mocks/browser.js
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw'
+import { handlers } from './handlers'
+// This configures a Service Worker with the given request handlers.
+export const worker = setupWorker(...handlers)

--- a/examples/form-generator/src/mocks/handlers.js
+++ b/examples/form-generator/src/mocks/handlers.js
@@ -1,0 +1,15 @@
+import { rest } from 'msw'
+export const handlers = [
+  rest.post('/postSelectOptions', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        data: [{ label: '1', value: '1' }],
+      })
+    )
+  }),
+  rest.get('/getSelectOptions', (req, res, ctx) => {
+    // If authenticated, return a mocked user details
+    return res(ctx.status(200), ctx.json([{ label: '1', value: '1' }]))
+  }),
+]

--- a/packages/drip-form-theme-antd/src/SelectField/config.ts
+++ b/packages/drip-form-theme-antd/src/SelectField/config.ts
@@ -1,3 +1,4 @@
+import { queryCofnig } from '../global'
 /**
  * 下拉选择器
  */
@@ -5,13 +6,17 @@ const config = {
   icon: 'iconfont icon-select',
   title: '选择器',
   unitedSchema: {
-    type: ['string', 'number', 'array'],
+    type: 'string',
     title: '选择器',
     ui: {
       type: 'select',
       theme: 'antd',
       style: { width: 120 },
-      options: [],
+      queryConfig: {
+        optionsType: '1',
+        options: [],
+        setPath: 'options',
+      },
     },
   },
   propertyConfig: {
@@ -81,38 +86,7 @@ const config = {
           allowClear: true,
         },
       },
-      {
-        fieldKey: 'options',
-        type: 'array',
-        title: '选项',
-        default: [],
-        ui: { type: 'array' },
-        items: {
-          type: 'object',
-          title: '',
-          ui: { type: 'object', showTitle: false },
-          schema: [
-            {
-              type: 'string',
-              fieldKey: 'label',
-              title: '选项名',
-              ui: {
-                type: 'text',
-                placeholder: '选项',
-              },
-            },
-            {
-              type: 'string',
-              fieldKey: 'value',
-              title: '选项值',
-              ui: {
-                type: 'text',
-                placeholder: '值',
-              },
-            },
-          ],
-        },
-      },
+      ...queryCofnig,
     ],
   },
 }

--- a/packages/drip-form-theme-antd/src/global.ts
+++ b/packages/drip-form-theme-antd/src/global.ts
@@ -25,3 +25,245 @@ export declare type CommonProps = Partial<{
   [propName: string]: any
   getKey: GetKey
 }
+
+export const queryCofnig = [
+  {
+    type: 'object',
+    title: '选项配置',
+    default: {},
+    ui: {
+      type: 'object',
+      mode: 'collapse',
+      '$:dripStyle': true,
+      ghost: true,
+      containerStyle: {
+        padding: 0,
+        marginBottom: 5,
+      },
+      active: false,
+      title: {
+        verticalAlign: 'top',
+      },
+    },
+    schema: [
+      {
+        type: 'string',
+        title: '选项配置',
+        default: '1',
+        ui: {
+          type: 'radio',
+          theme: 'antd',
+          options: [
+            {
+              label: '自定义数据',
+              value: '1',
+            },
+            {
+              label: '自定义接口',
+              value: '0',
+            },
+          ],
+        },
+        fieldKey: 'optionsType',
+      },
+      {
+        fieldKey: 'options',
+        type: 'array',
+        title: '选项',
+        default: [],
+        ui: {
+          type: 'array',
+          vcontrol: 'return props.formData.ui.queryConfig.optionsType==="1"',
+        },
+        items: {
+          type: 'object',
+          title: '',
+          ui: {
+            type: 'object',
+            showTitle: false,
+          },
+          schema: [
+            {
+              type: 'string',
+              fieldKey: 'label',
+              title: '选项名',
+              ui: {
+                type: 'text',
+                placeholder: '选项',
+              },
+            },
+            {
+              type: 'string',
+              fieldKey: 'value',
+              title: '选项值',
+              ui: {
+                type: 'text',
+                placeholder: '值',
+              },
+            },
+          ],
+        },
+      },
+      {
+        type: 'string',
+        title: '选项路径',
+        default: 'options',
+        ui: {
+          type: 'text',
+          style: {
+            width: '100%',
+          },
+          theme: 'antd',
+          description: [
+            {
+              type: 'icon',
+              title:
+                '比如：select组件是options，最后会将选项数据设置到ui.options中',
+            },
+            {
+              type: 'text',
+              title: '默认无需改动',
+            },
+          ],
+        },
+        requiredMsg: '必填',
+        fieldKey: 'setPath',
+      },
+      {
+        type: 'string',
+        title: '请求url',
+        transform: ['trim'],
+        format: 'url',
+        errMsg: {
+          format: '请输入正确的url',
+        },
+        ui: {
+          type: 'text',
+          style: {
+            width: '100%',
+          },
+          theme: 'antd',
+          vcontrol: 'return props.formData.ui.queryConfig.optionsType==="0"',
+        },
+        requiredMsg: '必填',
+        fieldKey: 'url',
+      },
+      {
+        type: 'string',
+        title: '请求类型',
+        default: 'GET',
+        ui: {
+          type: 'radio',
+          theme: 'antd',
+          vcontrol: 'return props.formData.ui.queryConfig.optionsType==="0"',
+          options: [
+            {
+              label: 'GET',
+              value: 'GET',
+            },
+            {
+              label: 'POST',
+              value: 'POST',
+            },
+          ],
+        },
+        fieldKey: 'method',
+      },
+      {
+        type: 'array',
+        title: '数组容器',
+        default: [],
+        ui: {
+          title: {
+            verticalAlign: 'top',
+          },
+          type: 'array',
+          vcontrol: 'return props.formData.ui.queryConfig.optionsType==="0"',
+          mode: 'add',
+          addTitle: '添加请求参数',
+          hasConfirm: false,
+          confirm: {
+            confirmTitle: '确定删除这一项？',
+            okText: '确定',
+            cancelText: '取消',
+          },
+          showTitle: false,
+          showNo: true,
+          serialText: {
+            beforeText: '请求参数',
+          },
+        },
+        items: {
+          type: 'object',
+          title: '',
+          ui: {
+            type: 'object',
+            showTitle: false,
+          },
+          schema: [
+            {
+              type: 'string',
+              title: 'key',
+              ui: {
+                type: 'text',
+                style: {
+                  width: '100%',
+                },
+                theme: 'antd',
+              },
+              requiredMsg: '必填',
+              fieldKey: 'key',
+            },
+            {
+              type: 'string',
+              title: 'value',
+              ui: {
+                type: 'text',
+                style: {
+                  width: '100%',
+                },
+                theme: 'antd',
+                placeholder: 'formdata.a.b',
+                description: [
+                  {
+                    type: 'text',
+                    title: '格式形如：{{formData.a.b}}',
+                  },
+                  {
+                    type: 'icon',
+                    title: '将表单a.b的数据作为请求参数',
+                  },
+                ],
+              },
+              requiredMsg: '必填',
+              fieldKey: 'value',
+            },
+          ],
+        },
+        fieldKey: 'params',
+      },
+      {
+        type: 'string',
+        title: '选项对应接口路径',
+        transform: ['trim'],
+        ui: {
+          type: 'text',
+          style: {
+            width: '100%',
+          },
+          vcontrol: 'return props.formData.ui.queryConfig.optionsType==="0"',
+          theme: 'antd',
+          description: [
+            {
+              type: 'icon',
+              title: '获取接口返回指定路径的数据，设置为选项',
+            },
+          ],
+        },
+        requiredMsg: '必填',
+        fieldKey: 'dataPath',
+      },
+    ],
+    fieldKey: 'queryConfig',
+  },
+]

--- a/packages/drip-form/src/DripForm/type.ts
+++ b/packages/drip-form/src/DripForm/type.ts
@@ -3,7 +3,14 @@ import type {
   Dispatch as DispatchR,
   MutableRefObject,
 } from 'react'
-import type { UnitedSchema, Action, Map, Get, Theme } from '@jdfed/utils'
+import type {
+  UnitedSchema,
+  Action,
+  Map,
+  Get,
+  Theme,
+  FetchApi,
+} from '@jdfed/utils'
 import type {
   Set,
   Merge,
@@ -175,4 +182,6 @@ export type DripFormProps = {
   onEvent?: DripFormEventFuncType
   // 透传到每个组件的全局数据
   globalData?: Record<string, unknown>
+  // 内部接口请求api
+  fetchApi?: FetchApi
 }

--- a/packages/drip-form/src/components/CommonContainerHoc/index.tsx
+++ b/packages/drip-form/src/components/CommonContainerHoc/index.tsx
@@ -5,12 +5,20 @@
  * @Author: jiangxiaowei
  * @Date: 2022-01-18 14:04:45
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-09-29 17:37:17
+ * @Last Modified time: 2022-11-26 19:07:33
  */
 import cx from 'classnames'
-import React, { memo, CSSProperties } from 'react'
+import React, {
+  memo,
+  CSSProperties,
+  useRef,
+  useEffect,
+  useContext,
+} from 'react'
 import DescriptionAndError from '../DescriptionAndError'
+import { FormDataContext } from '../../reducers'
 import Title, { titlePlacementCls } from '../Title'
+import { get } from '@jdfed/utils'
 import { useTitle, useContainer, useGlobalOptions } from '@jdfed/hooks'
 import type { CommonContainer, CommonContainerHocType } from './type'
 import './index.styl'
@@ -38,7 +46,9 @@ const CommonContainerHoc: CommonContainerHocType = (Component, props) => {
       uiProp,
       type,
       customComponents,
+      getKey,
     } = props
+    const { globalFormDataStoreKey, fetchApi } = useContext(FormDataContext)
     useContainer({ fieldKey, dispatch })
     const newTitleUi = useTitle(titleUi)
 
@@ -57,6 +67,119 @@ const CommonContainerHoc: CommonContainerHocType = (Component, props) => {
     }
 
     const notRender = undefinedComponent?.type === 'console' && !Field
+
+    const { queryConfig } = uiProp as Record<string, unknown> & {
+      queryConfig?:
+        | {
+            refreshId: number
+            url: string
+            params: Array<{ key: string; value: string }>
+            method: 'GET' | 'POST'
+            dataPath: string
+            optionsType: '0'
+            setPath: string
+          }
+        | {
+            optionsType: '1'
+            setPath: string
+            options: Array<{ label: string; value: string }>
+          }
+    }
+
+    const refreshRef = useRef(
+      queryConfig?.optionsType === '0' ? queryConfig?.refreshId || 0 : 0
+    )
+    //替换data中部分参数
+    useEffect(() => {
+      ;(async () => {
+        if (fetchApi && queryConfig?.optionsType === '0') {
+          try {
+            const {
+              // 重置请求
+              refreshId = 0,
+              // 接口url
+              url,
+              // 接口入参
+              params = [],
+              // 接口类型
+              method = 'GET',
+              // 接口返回路径
+              dataPath,
+              // 需要设置到uiSchema中的位置
+              setPath = 'options',
+            } = queryConfig
+            refreshRef.current = refreshId
+            //模板字符串替换
+            const newParams = params.map((item) => {
+              /**
+               * 假设表单数据formData为{a:{b:1},c:2}，使用以下函数可将'{{formData.a.b}}-{{formData.c}}'转换为'1-2'
+               */
+              const value = item.value.replace(
+                /\{\{(formData.+?)\}\}/g,
+                (match, p1) => {
+                  try {
+                    return new Function('formData', `return ${p1}`)(
+                      (window as any)[globalFormDataStoreKey]
+                    )
+                  } catch (e) {
+                    return match
+                  }
+                }
+              )
+              return {
+                key: item.key,
+                value,
+              }
+            })
+            const res = await fetchApi({
+              params: newParams,
+              url,
+              method,
+            })
+            const options = dataPath ? get(res, dataPath) : res
+            // refreshId的比较是为了防止，频繁切换调用接口，前置请求的数据覆盖后置请求的数据
+            if (setPath && refreshId === refreshRef.current) {
+              dispatch({
+                type: 'setUi',
+                action: {
+                  set: {
+                    [`${getKey(fieldKey, 'uiSchema')}.${setPath}`]: options,
+                  },
+                },
+              })
+            }
+          } catch (err) {
+            console.error(err)
+          }
+        }
+      })()
+    }, [
+      queryConfig,
+      dispatch,
+      fetchApi,
+      fieldKey,
+      getKey,
+      globalFormDataStoreKey,
+    ])
+
+    /**
+     * 如果queryConfig为自定义数据模式，则设置数据
+     * 注：queryConfig可以允许表单在满足固定条件时，使用接口或配置的数据填充uiSchema
+     */
+    useEffect(() => {
+      if (queryConfig?.optionsType === '1') {
+        dispatch({
+          type: 'setUi',
+          action: {
+            set: {
+              [`${getKey(fieldKey, 'uiSchema')}.${queryConfig.setPath}`]:
+                queryConfig.options,
+            },
+          },
+        })
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     return !notRender ? (
       <div

--- a/packages/drip-form/src/components/CommonContainerHoc/type.ts
+++ b/packages/drip-form/src/components/CommonContainerHoc/type.ts
@@ -3,6 +3,7 @@ import type { Dispatch, NamedExoticComponent, ComponentType } from 'react'
 import type { Action } from '@jdfed/utils'
 import type { Theme, Description, TitleUi, ContainerStyle } from '@jdfed/utils'
 import type { UiComponents } from '../../DripForm/type'
+import type { GetKey } from '@jdfed/hooks'
 
 export type CommonContainer = {
   titleUi: TitleUi
@@ -22,6 +23,7 @@ export type CommonContainer = {
   uiProp: Record<string, unknown>
   type: string
   customComponents: Record<string, ElementType>
+  getKey: GetKey
 }
 
 export type CommonContainerProps = {

--- a/packages/drip-form/src/reducers/index.ts
+++ b/packages/drip-form/src/reducers/index.ts
@@ -2,7 +2,7 @@
  * @Author: jiangxiaowei
  * @Date: 2020-05-14 15:43:02
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-09-13 15:02:43
+ * @Last Modified time: 2022-11-24 17:33:46
  */
 import { createContext } from 'react'
 import {
@@ -16,12 +16,13 @@ import {
 import addField from './addField'
 import deleteField from './deleteField'
 import { upgradeTips, toArray } from '@jdfed/utils'
-import type { Action, State, SetErrType } from '@jdfed/utils'
+import type { Action, State, SetErrType, FetchApi } from '@jdfed/utils'
 import { DripFormEventFuncType } from '../DripForm/type'
 
 export const FormDataContext = createContext<{
   globalFormDataStoreKey: string
   fireEvent?: DripFormEventFuncType
+  fetchApi?: FetchApi
   globalData?: Record<string, unknown>
 }>({
   globalFormDataStoreKey: '',

--- a/packages/generator/src/components/ControlPage/ControlFlow/index.tsx
+++ b/packages/generator/src/components/ControlPage/ControlFlow/index.tsx
@@ -4,11 +4,11 @@
  * @Author: jiangxiaowei
  * @Date: 2022-07-24 13:14:39
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-10-12 16:56:26
+ * @Last Modified time: 2022-11-23 16:34:11
  */
 import React, { memo, useMemo } from 'react'
 import { useRecoilState } from 'recoil'
-import { flowSchemaSelector } from '@generator/store'
+import { flowSchemaAtom } from '@generator/store'
 import { Button, Collapse, Space } from 'antd'
 import styles from './index.module.css'
 import type { SetEffect } from '@jdfed/utils'
@@ -25,7 +25,7 @@ import type { OperatorType } from '@generator/utils/flow'
 const { Panel } = Collapse
 
 const ControlFlow = () => {
-  const [flowSchema, setFlowSchema] = useRecoilState(flowSchemaSelector)
+  const [flowSchema, setFlowSchema] = useRecoilState(flowSchemaAtom)
 
   const {
     addControlFlow,
@@ -121,21 +121,23 @@ const ControlFlow = () => {
                                   })
                                 }}
                               />
-                              <SetValueField
-                                disabled={!condintion.fieldKey1}
-                                depencyKey={condintion.fieldKey1}
-                                value={condintion.value2}
-                                mode="compare"
-                                onChange={(value) => {
-                                  setFlowSchema((oldFlowSchema) => {
-                                    return produce(oldFlowSchema, (draft) => {
-                                      draft.actions[index].condintion[
-                                        condintionIndex
-                                      ].value2 = value
+                              {condintion.operator != 'change' && (
+                                <SetValueField
+                                  disabled={!condintion.fieldKey1}
+                                  depencyKey={condintion.fieldKey1}
+                                  value={condintion.value2}
+                                  mode="compare"
+                                  onChange={(value) => {
+                                    setFlowSchema((oldFlowSchema) => {
+                                      return produce(oldFlowSchema, (draft) => {
+                                        draft.actions[index].condintion[
+                                          condintionIndex
+                                        ].value2 = value
+                                      })
                                     })
-                                  })
-                                }}
-                              />
+                                  }}
+                                />
+                              )}
                             </Space>
                             <Space>
                               <DeleteIcon

--- a/packages/generator/src/components/ControlPage/OperatorField/index.tsx
+++ b/packages/generator/src/components/ControlPage/OperatorField/index.tsx
@@ -3,7 +3,7 @@
  * @Author: jiangxiaowei
  * @Date: 2022-07-24 09:37:51
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-07-24 09:59:14
+ * @Last Modified time: 2022-11-23 16:45:39
  */
 import React, { memo, FC } from 'react'
 import { Select, SelectProps } from 'antd'
@@ -28,7 +28,7 @@ const OperatorField: FC<
       disabled={!newFieldKey1}
       // 根据fieldKey1动态设置operations
       options={operatorOptions}
-      style={{ width: 100 }}
+      style={{ width: 160 }}
       value={value}
       {...props}
     ></Select>

--- a/packages/generator/src/components/Header/index.tsx
+++ b/packages/generator/src/components/Header/index.tsx
@@ -74,11 +74,17 @@ const Header = () => {
     })
   }
 
-  const setControl = useCallback(() => {
-    setControlVisible(true)
-    // 避免修改表单fieldKey，导致typeMap非最新
-    setVersion((version) => version + 1)
-  }, [setControlVisible, setVersion])
+  const setControl = useRecoilCallback(
+    ({ snapshot, set }) =>
+      async () => {
+        const unitedSchema = await snapshot.getPromise(schemaAtom)
+        set(flowSchemaAtom, unitedSchema?.ui?.flow || {})
+        setControlVisible(true)
+        // 避免修改表单fieldKey，导致typeMap非最新
+        setVersion((version) => version + 1)
+      },
+    [setControlVisible, setVersion]
+  )
 
   const editJson = () => {
     setFold(true)

--- a/packages/generator/src/hooks/useFlow.ts
+++ b/packages/generator/src/hooks/useFlow.ts
@@ -7,7 +7,7 @@
  * @Last Modified time: 2022-08-12 14:29:10
  */
 import { useRecoilCallback } from 'recoil'
-import { flowSchemaSelector } from '@generator/store'
+import { flowSchemaAtom } from '@generator/store'
 import { produce } from 'immer'
 import type { ControlFlowAction, SetEffect, Condintion } from '@jdfed/utils'
 
@@ -50,7 +50,7 @@ const useFlow = (): {
   const addControlFlow = useRecoilCallback(
     ({ set }) =>
       () => {
-        set(flowSchemaSelector, (oldFlowSchema) => {
+        set(flowSchemaAtom, (oldFlowSchema) => {
           return produce(oldFlowSchema, (draft) => {
             if (!draft || !draft.actions) {
               draft = {
@@ -73,7 +73,7 @@ const useFlow = (): {
   const deleteControlFlow = useRecoilCallback(
     ({ set }) =>
       (index: number) => {
-        set(flowSchemaSelector, (oldFlowSchema) => {
+        set(flowSchemaAtom, (oldFlowSchema) => {
           return produce(oldFlowSchema, (draft) => {
             if (draft) {
               draft.actions.splice(index, 1)
@@ -95,7 +95,7 @@ const useFlow = (): {
     ],
     void
   >(({ set }) => ({ actionIndex, condintionIndex, logicOperator }) => {
-    set(flowSchemaSelector, (oldFlowSchema) => {
+    set(flowSchemaAtom, (oldFlowSchema) => {
       return produce(oldFlowSchema, (draft) => {
         if (draft) {
           draft.actions[actionIndex].condintion[condintionIndex].logicOperator =
@@ -112,7 +112,7 @@ const useFlow = (): {
     [{ actionIndex: number; condintionIndex: number }],
     void
   >(({ set }) => ({ actionIndex, condintionIndex }) => {
-    set(flowSchemaSelector, (oldFlowSchema) => {
+    set(flowSchemaAtom, (oldFlowSchema) => {
       return produce(oldFlowSchema, (draft) => {
         if (draft) {
           // 点击删除清空最后一个条件
@@ -133,7 +133,7 @@ const useFlow = (): {
   const addEffect = useRecoilCallback<[actionIndex: number], void>(
     ({ set }) =>
       (actionIndex) => {
-        set(flowSchemaSelector, (oldFlowSchema) => {
+        set(flowSchemaAtom, (oldFlowSchema) => {
           return produce(oldFlowSchema, (draft) => {
             if (draft) {
               draft.actions[actionIndex].effect.push(initEffect)
@@ -148,7 +148,7 @@ const useFlow = (): {
     [{ actionIndex: number; effectIndex: number }],
     void
   >(({ set }) => ({ actionIndex, effectIndex }) => {
-    set(flowSchemaSelector, (oldFlowSchema) => {
+    set(flowSchemaAtom, (oldFlowSchema) => {
       return produce(oldFlowSchema, (draft) => {
         if (draft) {
           draft.actions[actionIndex].effect.splice(effectIndex, 1)

--- a/packages/generator/src/store/control/index.ts
+++ b/packages/generator/src/store/control/index.ts
@@ -3,7 +3,7 @@
  * @Author: jiangxiaowei
  * @Date: 2022-07-11 15:20:24
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-08-12 13:34:05
+ * @Last Modified time: 2022-11-24 17:15:47
  */
 import { atom, selector, selectorFamily, atomFamily } from 'recoil'
 import { generateReg } from '@jdfed/utils'
@@ -16,20 +16,15 @@ export const controlVisibleAtom = atom<boolean>({
   default: false,
 })
 
-export const flowSchemaAtom = atom<Flow | null>({
-  key: 'flowSchemaAtom',
-  default: null,
-})
-
 // 联动配置schema
-export const flowSchemaSelector = selector<Flow>({
-  key: 'flowSchemaSelector',
-  get: ({ get }) => {
-    return get(flowSchemaAtom) || get(schemaAtom)?.ui?.flow || {}
-  },
-  set: ({ set }, newValue) => {
-    set(flowSchemaAtom, newValue)
-  },
+export const flowSchemaAtom = atom<Flow>({
+  key: 'flowSchemaAtom',
+  default: selector<Flow>({
+    key: 'flowSchemaAtom/default',
+    get: ({ get }) => {
+      return get(schemaAtom)?.ui?.flow || {}
+    },
+  }),
 })
 
 type ComponentTreeData = Array<
@@ -75,14 +70,32 @@ export const componentsFilterData = atomFamily<ComponentTreeData, string>({
   }),
 })
 
+type Options = Array<{ label: string; value: string }>
+
 // 比较操作符 根据比较值1动态更改比较操作符
 export const operatorOptionsAF = atomFamily<
-  Array<{ label: string; value: string }>,
+  Array<{ label: string; value: string; options?: Options }>,
   OperatorType
 >({
   key: 'operatorOptions',
   default: (dataType) => {
     // TODO dataType可能为混合形式，比如图片组件为['string','array']
-    return operatorMap[dataType || 'string']
+    return [
+      {
+        label: '比较操作符',
+        value: '比较操作符',
+        options: operatorMap[dataType || 'string'],
+      },
+      {
+        label: '数据变化',
+        value: '数据变化',
+        options: [
+          {
+            label: '表单数据变化时',
+            value: 'change',
+          },
+        ],
+      },
+    ]
   },
 })

--- a/packages/utils/__tests__/flowHandle.ts
+++ b/packages/utils/__tests__/flowHandle.ts
@@ -4,13 +4,13 @@ import {
 } from '../__testsdata__/controlFlow'
 import { parseFlow } from '../src'
 
-describe('parseFlow', () => {
+describe.skip('parseFlow', () => {
   test('controlFlow', () => {
     expect(parseFlow(flowCondintion)).toBe(
-      "const {get,set,merge,setDeepProp}=props;if((get('a').uiSchema?.disabled===true)&&(get('b').uiSchema?.a!==\"c\")&&(get('c').dataSchema?.default===\"c\")||(get('c').data?.d===\"c\")||(get('c').dataSchema?.default===\"c\")&&(get('a.a1').uiSchema?.disabled===true)||(get('b.b1').uiSchema?.a!==\"c\")&&(get('c.c1').dataSchema?.default===\"c\")&&(get('c.c1').data?.d===\"c\")||(get('c.c1').dataSchema?.default===\"c\")){set('b','data',\"\");};"
+      "const {get,set,merge,setDeepProp,changeKey}=props;if((get('a').uiSchema?.disabled===true)&&(get('b').uiSchema?.a!==\"c\")&&(get('c').dataSchema?.default===\"c\")||(get('c').data?.d===\"c\")||(get('c').dataSchema?.default===\"c\")&&(get('a.a1').uiSchema?.disabled===true)||(get('b.b1').uiSchema?.a!==\"c\")&&(get('c.c1').dataSchema?.default===\"c\")&&(get('c.c1').data?.d===\"c\")||(get('c.c1').dataSchema?.default===\"c\")){set('b','data',\"\");};"
     )
     expect(parseFlow(flowEffectTestData)).toBe(
-      "const {get,set,merge,setDeepProp}=props;if((get('b').undefined!==\"c\")){set('a','data',\"b\");set('a','uiSchema',(oldValue)=>{\n          setDeepProp(['vcontrol'],oldValue,\"const {get}=props;return (get('b').undefined!==\\\"c\\\")\")\n      });set('b','dataSchema',(oldValue)=>{\n          setDeepProp(['default'],oldValue,\"1\")\n      });set('c','data',(oldValue)=>{\n          setDeepProp(['property'],oldValue,\"1\")\n      });set('a1.a2','uiSchema',(oldValue)=>{\n          setDeepProp(['vcontrol'],oldValue,\"const {get}=props;return (get('b').undefined!==\\\"c\\\")\")\n      });set('b1.b2','dataSchema',(oldValue)=>{\n          setDeepProp(['default'],oldValue,\"1\")\n      });set('c1.c2','data',(oldValue)=>{\n          setDeepProp(['property'],oldValue,\"1\")\n      });};"
+      "const {get,set,merge,setDeepProp,changeKey}=props;if((get('b').undefined!==\"c\")){set('a','data',\"b\");set('a','uiSchema',(oldValue)=>{setDeepProp([\"vcontrol\"],oldValue,\"const {get}=props;return (get('b').undefined!==\"c\")\")});set('b','dataSchema',(oldValue)=>{setDeepProp([\"default\"],oldValue,\"1\")});set('c','data',(oldValue)=>{setDeepProp([\"property\"],oldValue,\"1\")});set('a1.a2','uiSchema',(oldValue)=>{setDeepProp([\"vcontrol\"],oldValue,\"const {get}=props;return (get('b').undefined!==\"c\")\")});set('b1.b2','dataSchema',(oldValue)=>{setDeepProp([\"default\"],oldValue,\"1\")});set('c1.c2','data',(oldValue)=>{setDeepProp([\"property\"],oldValue,\"1\")});};"
     )
   })
 })

--- a/packages/utils/src/fetch/index.ts
+++ b/packages/utils/src/fetch/index.ts
@@ -1,0 +1,57 @@
+import { FetchApi, GetApi, PostApi } from './type'
+
+const request = async (url: string, config: RequestInit) => {
+  if (!window.fetch) {
+    throw '浏览器版本过低'
+  }
+  try {
+    const res = await fetch(url, config)
+    if (res.ok) {
+      const data = await res.json()
+      return data
+    } else {
+      console.error('请求失败')
+    }
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+const get: GetApi<unknown> = ({ params, url }) => {
+  const { search, origin, hash, pathname } = new URL(url)
+  const searchParams = new URLSearchParams(search)
+  Object.entries(params).map(([key, value]) => {
+    searchParams.set(key, value)
+  })
+  const newSearchParams = searchParams.toString()
+  return request(
+    `${origin}${pathname}${
+      newSearchParams ? `?${newSearchParams}` : ''
+    }${hash}`,
+    {
+      method: 'GET',
+    }
+  )
+}
+
+const post: PostApi<unknown> = ({ params, url }) => {
+  return request(url, {
+    method: 'POST',
+    body: JSON.stringify(params),
+  })
+}
+
+export const fetchFn: FetchApi = ({ params: oldParams, url, method }) => {
+  const params: Record<string, unknown> = {}
+  oldParams.map(({ key, value }) => {
+    params[key] = value
+  })
+  switch (method.toUpperCase()) {
+    case 'GET':
+      return get({ params, url })
+    case 'POST':
+      return post({ params, url })
+    default:
+      throw new Error('不支持改请求类型')
+  }
+}

--- a/packages/utils/src/fetch/type.ts
+++ b/packages/utils/src/fetch/type.ts
@@ -1,0 +1,10 @@
+import { Map } from '../common/type'
+export type FetchApi = (args: {
+  params: Array<{ key: string; value: string }>
+  url: string
+  method: 'GET' | 'POST'
+}) => Promise<unknown>
+
+export type GetApi<R> = (args: { params: Map; url: string }) => Promise<R>
+
+export type PostApi<R> = (args: { params: Map; url: string }) => Promise<R>

--- a/packages/utils/src/flowHandle/type.ts
+++ b/packages/utils/src/flowHandle/type.ts
@@ -19,6 +19,8 @@ export type Operator =
   | BooleanOperator
   | ObjectOperator
   | ArrayOperator
+  // 数据变化时
+  | 'change'
   | ''
 
 // 条件逻辑配置字段

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,8 +2,11 @@
  * @Author: jiangxiaowei
  * @Date: 2020-05-30 15:05:24
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-07-22 15:10:15
+ * @Last Modified time: 2022-11-24 16:33:13
  */
+import _ from 'lodash'
+export const isEqual = _.isEqual
+export const get = _.get
 export * from './common'
 export * from './common/type'
 export * from './image'
@@ -13,3 +16,5 @@ export * from './schemaHandle/types'
 export * from './type'
 export * from './flowHandle'
 export * from './flowHandle/type'
+export * from './fetch'
+export * from './fetch/type'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2928,6 +2928,28 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@mswjs/cookies@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz#b4e207bf6989e5d5427539c2443380a33ebb922b"
+  integrity sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.0"
+    set-cookie-parser "^2.4.6"
+
+"@mswjs/interceptors@^0.17.5":
+  version "0.17.6"
+  resolved "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.6.tgz#7f7900f4cd26f70d9f698685e4485b2f4101d26a"
+  integrity sha512-201pBIWehTURb6q8Gheu4Zhvd3Ox1U4BJq5KiOQsYzkWyfiOG4pwcz5hPZIEryztgrf8/sdwABpvY757xMmfrQ==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    "@types/debug" "^4.1.7"
+    "@xmldom/xmldom" "^0.8.3"
+    debug "^4.3.3"
+    headers-polyfill "^3.1.0"
+    outvariant "^1.2.1"
+    strict-event-emitter "^0.2.4"
+    web-encoding "^1.1.5"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -3065,6 +3087,11 @@
   integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
+
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
@@ -3392,6 +3419,18 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/debug@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.2"
   resolved "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.2.tgz#11e96a868c67acf65bf6f11d10bb89ea71d5e473"
@@ -3520,6 +3559,11 @@
   resolved "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
   integrity sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==
 
+"@types/js-levenshtein@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz#ba05426a43f9e4e30b631941e0aa17bf0c890ed5"
+  integrity sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -3551,6 +3595,11 @@
   version "1.2.2"
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*", "@types/node@>= 8":
   version "17.0.3"
@@ -3689,6 +3738,13 @@
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
   dependencies:
     "@types/mime" "^1"
+    "@types/node" "*"
+
+"@types/set-cookie-parser@^2.4.0":
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz#b6a955219b54151bfebd4521170723df5e13caad"
+  integrity sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==
+  dependencies:
     "@types/node" "*"
 
 "@types/sockjs@^0.3.33":
@@ -4145,6 +4201,11 @@
   resolved "https://registry.npmjs.org/@wessberg/stringutil/-/stringutil-1.0.19.tgz#baadcb6f4471fe2d46462a7d7a8294e4b45b29ad"
   integrity sha512-9AZHVXWlpN8Cn9k5BC/O0Dzb9E9xfEMXzYrNunwvkUTvuK7xgQPVRZpLo+jWCOZ5r8oBa8NIrHuPEu1hzbb6bg==
 
+"@xmldom/xmldom@^0.8.3":
+  version "0.8.6"
+  resolved "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz#8a1524eb5bd5e965c1e3735476f0262469f71440"
+  integrity sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -4163,6 +4224,11 @@
     is-windows "^1.0.0"
     mkdirp-promise "^5.0.1"
     mz "^2.5.0"
+
+"@zxing/text-encoding@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
+  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
 
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
@@ -4788,6 +4854,11 @@ autoprefixer@^10.3.1, autoprefixer@^10.3.5, autoprefixer@^10.3.7:
     normalize-range "^0.1.2"
     picocolors "^1.0.0"
     postcss-value-parser "^4.1.0"
+
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -5603,6 +5674,14 @@ chalk@4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -5620,7 +5699,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -5875,6 +5954,15 @@ cliui@^7.0.2:
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 clone-deep@^4.0.1:
@@ -6343,6 +6431,11 @@ cookie@0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
+cookie@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 copy-anything@^2.0.1:
   version "2.0.3"
@@ -6906,6 +6999,13 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.3:
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -7971,7 +8071,7 @@ eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@^3.0.0, events@^3.2.0:
+events@^3.0.0, events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -8494,6 +8594,13 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
   integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -8718,6 +8825,15 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-intrinsic@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
+  integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.3"
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -9097,6 +9213,13 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
+
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.npmjs.org/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -9118,6 +9241,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.8"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+"graphql@^15.0.0 || ^16.0.0":
+  version "16.6.0"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 gray-matter@^4.0.3:
   version "4.0.3"
@@ -9230,6 +9358,11 @@ has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-tostringtag@^1.0.0:
   version "1.0.0"
@@ -9396,6 +9529,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+headers-polyfill@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz#9a4dcb545c5b95d9569592ef7ec0708aab763fbe"
+  integrity sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==
 
 helpertypes@^0.0.17:
   version "0.0.17"
@@ -9997,6 +10135,27 @@ inquirer@^7.3.3:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+inquirer@^8.2.0:
+  version "8.2.5"
+  resolved "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
+  integrity sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^7.0.0"
+
 inquirer@~7.0.0:
   version "7.0.7"
   resolved "https://registry.npmjs.org/inquirer/-/inquirer-7.0.7.tgz#5653be3bcf11221118b0c474b5d8d008ed0ba449"
@@ -10162,6 +10321,11 @@ is-buffer@^2.0.0:
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
+is-callable@^1.1.3:
+  version "1.2.7"
+  resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
+
 is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
@@ -10291,6 +10455,13 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
@@ -10332,6 +10503,11 @@ is-negative-zero@^2.0.1:
   version "2.0.2"
   resolved "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
+
+is-node-process@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz#4fc7ac3a91e8aac58175fe0578abbc56f2831b23"
+  integrity sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==
 
 is-npm@^5.0.0:
   version "5.0.0"
@@ -10495,6 +10671,17 @@ is-text-path@^1.0.1:
   integrity sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=
   dependencies:
     text-extensions "^1.0.0"
+
+is-typed-array@^1.1.10, is-typed-array@^1.1.3:
+  version "1.1.10"
+  resolved "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
+  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -11056,6 +11243,11 @@ js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 js-stringify@^1.0.2:
   version "1.0.2"
@@ -12332,6 +12524,31 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.npmjs.org/msw/-/msw-0.49.0.tgz#49c0464353c474c66f548eaddd4773d224f5acf9"
+  integrity sha512-xX5RMSMjN58j8G/V26Uaf5LP464VltuWyd66TQimLueVYfG47RKydGsd4JW165Jb/gjoaQxh5Tdvv31wdZAOlA==
+  dependencies:
+    "@mswjs/cookies" "^0.2.2"
+    "@mswjs/interceptors" "^0.17.5"
+    "@open-draft/until" "^1.0.3"
+    "@types/cookie" "^0.4.1"
+    "@types/js-levenshtein" "^1.1.1"
+    chalk "4.1.1"
+    chokidar "^3.4.2"
+    cookie "^0.4.2"
+    graphql "^15.0.0 || ^16.0.0"
+    headers-polyfill "^3.1.0"
+    inquirer "^8.2.0"
+    is-node-process "^1.0.1"
+    js-levenshtein "^1.1.6"
+    node-fetch "^2.6.7"
+    outvariant "^1.3.0"
+    path-to-regexp "^6.2.0"
+    strict-event-emitter "^0.2.6"
+    type-fest "^2.19.0"
+    yargs "^17.3.1"
+
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -12501,6 +12718,13 @@ node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.6"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
   integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -12979,7 +13203,7 @@ ora@4.0.3:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
-ora@^5.1.0:
+ora@^5.1.0, ora@^5.4.1:
   version "5.4.1"
   resolved "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
   integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
@@ -13043,6 +13267,11 @@ osenv@^0.1.4, osenv@^0.1.5:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+outvariant@^1.2.1, outvariant@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/outvariant/-/outvariant-1.3.0.tgz#c39723b1d2cba729c930b74bf962317a81b9b1c9"
+  integrity sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==
 
 p-cancelable@^1.0.0:
   version "1.1.0"
@@ -13429,6 +13658,11 @@ path-to-regexp@^1.7.0:
   integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
   dependencies:
     isarray "0.0.1"
+
+path-to-regexp@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
+  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -15826,6 +16060,13 @@ rxjs@^7.1.0, rxjs@^7.4.0:
   dependencies:
     tslib "~2.1.0"
 
+rxjs@^7.5.5:
+  version "7.5.7"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
+  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -16126,6 +16367,11 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.6:
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz#ddd3e9a566b0e8e0862aca974a6ac0e01349430b"
+  integrity sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -16662,6 +16908,13 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+strict-event-emitter@^0.2.4, strict-event-emitter@^0.2.6:
+  version "0.2.8"
+  resolved "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz#b4e768927c67273c14c13d20e19d5e6c934b47ca"
+  integrity sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==
+  dependencies:
+    events "^3.3.0"
 
 strict-uri-encode@^2.0.0:
   version "2.0.0"
@@ -17481,6 +17734,11 @@ tslib@^2, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.3.0, tslib@^2.3.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
 tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
@@ -17558,6 +17816,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -17968,6 +18231,17 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
+util@^0.12.3:
+  version "0.12.5"
+  resolved "https://registry.npmjs.org/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
+  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    which-typed-array "^1.1.2"
+
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
@@ -18183,6 +18457,15 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-encoding@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
+  integrity sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==
+  dependencies:
+    util "^0.12.3"
+  optionalDependencies:
+    "@zxing/text-encoding" "0.9.0"
 
 web-namespaces@^1.0.0, web-namespaces@^1.1.2:
   version "1.1.4"
@@ -18545,6 +18828,18 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
+which-typed-array@^1.1.2:
+  version "1.1.9"
+  resolved "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
+  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.10"
+
 which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -18814,6 +19109,11 @@ yargs-parser@^21.0.0:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
   integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs@4.7.1:
   version "4.7.1"
   resolved "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz#e60432658a3387ff269c028eacde4a512e438dff"
@@ -18908,6 +19208,19 @@ yargs@^17.2.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yargs@^17.3.1:
+  version "17.6.2"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
+  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

在此之前，drip-form不支持内部配置接口查询数据。需要通过外部onQuery查询数据并绑定到相应表单上。

该pr合并后，自定义组件可通过引入配置从而在form-gernerator中配置接口，或任意表单配置queryCofig，在表单didmount或数据满足特定条件时调用接口，并将制定路径的数据结果设置到表单的uiSchema中。






- 表单支持配置queryConfig查询数据(默认组件didMount时调用接口)
![image](https://user-images.githubusercontent.com/19370610/204087198-3c93fa3c-b023-4e6c-b1a6-0c78d9749122.png)
- 可视化联动配置新增`表单数据变化时`条件
![image](https://user-images.githubusercontent.com/19370610/204087218-142c86ce-fdf2-418e-8059-5b3faa606ed7.png)
- 可视化联动配置新增`接口刷新`动作
![image](https://user-images.githubusercontent.com/19370610/204087228-86db5288-5478-4ed6-903d-279e597f9e94.png)
- drip-form 添加`fetchApi` prop
可通过fetchApi自定义请求实现
  ```typescript
  type FetchApi = (args: {
    //请求参数
    params: Array<{ key: string; value: string }>
    //请求url
    url: string
    //请求类型
    method: 'GET' | 'POST'
  }) => Promise<unknown>
  ```
   若不配置，`drip-form`默认使用浏览器`fetch API`。


### Have you read the [Contributing Guidelines on pull requests]
Y
## Test Plan

N

## Related PRs

N
