### PR TITLE
feat(form): block queryConfig requests in generator mode

### DIFF
--- a/packages/drip-form/src/components/CommonContainerHoc/index.tsx
+++ b/packages/drip-form/src/components/CommonContainerHoc/index.tsx
@@ -5,7 +5,7 @@
  * @Author: jiangxiaowei
  * @Date: 2022-01-18 14:04:45
  * @Last Modified by: jiangxiaowei
- * @Last Modified time: 2022-11-26 19:07:33
+ * @Last Modified time: 2022-12-15 13:54:02
  */
 import cx from 'classnames'
 import React, {
@@ -92,7 +92,11 @@ const CommonContainerHoc: CommonContainerHocType = (Component, props) => {
     //替换data中部分参数
     useEffect(() => {
       ;(async () => {
-        if (fetchApi && queryConfig?.optionsType === '0') {
+        if (
+          fetchApi &&
+          queryConfig?.optionsType === '0' &&
+          formMode !== 'generator'
+        ) {
           try {
             const {
               // 重置请求
@@ -155,6 +159,7 @@ const CommonContainerHoc: CommonContainerHocType = (Component, props) => {
       })()
     }, [
       queryConfig,
+      formMode,
       dispatch,
       fetchApi,
       fieldKey,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
当配置了queryConfig时，在@jdfed/form-generator 中间可视区，会默认触发请求，并将请求结果设置到json中。

此功能合并后，在generator模式下，不会触发queryConfig配置的请求。

可在表单预览弹框中，查看queryConfig配置效果

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N
