### PR TITLE
feat: 新增showError替代validateTime,区分实时,提交时和不展示3种错误展示策略

### DIFF
--- a/examples/form-generator/src/App/schema.js
+++ b/examples/form-generator/src/App/schema.js
@@ -1,10 +1,18 @@
 export default {
   type: 'object',
-  validateTime: 'change',
+  showError: 'change',
   ui: {
     title: {
       width: 82,
       placement: 'left',
+    },
+    footer: {
+      onOk: {
+        text: '保存',
+        type: 'primary',
+        size: 'middle',
+        shape: 'squash',
+      },
     },
     flow: {
       version: '0.1.0',
@@ -70,6 +78,7 @@ export default {
         },
         theme: 'antd',
       },
+      requiredMsg: '必填',
       fieldKey: 'text_lkXQ-Y',
     },
     {

--- a/packages/ajv/src/index.ts
+++ b/packages/ajv/src/index.ts
@@ -49,6 +49,7 @@ function registerAjv(options?: Options): Ajv {
   // 添加drip-form官方忽略关键字(添加customFormat是为了node校验支持旧版的语法)
   ajv.addVocabulary([
     'validateTime',
+    'showError',
     'requiredMode',
     '$container',
     // 用于绑定generator 切换的fieldKey

--- a/packages/drip-form/src/DripForm/index.tsx
+++ b/packages/drip-form/src/DripForm/index.tsx
@@ -311,6 +311,12 @@ const DripForm = forwardRef<DripFormRefType, DripFormRenderProps>(
 
     // 提交表单
     const submit = useCallback<DripFormRefType['submit']>(() => {
+      const showError = get('').dataSchema.showError
+      if (showError === 'submit') {
+        merge('', 'dataSchema', {
+          showError: 'change',
+        })
+      }
       const onValidateResMap: Record<string, any> = {}
       Object.entries(onValidate).map(([key, value]) => {
         if (value.type === 'submit') {
@@ -348,7 +354,7 @@ const DripForm = forwardRef<DripFormRefType, DripFormRenderProps>(
         .then(() => {
           return submitReturn.current
         })
-    }, [dispatch, get, onValidate])
+    }, [dispatch, get, merge, onValidate])
 
     // 重置表单
     const reset = useCallback(() => {

--- a/packages/drip-form/src/render/index.tsx
+++ b/packages/drip-form/src/render/index.tsx
@@ -70,7 +70,9 @@ const Render = ({
     type: parentType = 'object',
   } = currentUiSchema
   // 表单是否在下方直接展示错误信息
-  const showError = dataSchema.validateTime === 'change'
+  const showError = dataSchema.showError
+    ? dataSchema.showError === 'change'
+    : dataSchema.validateTime === 'change'
   return (order || []).map((item: string, i: number) => {
     // 当前Field ui类型
     const type = properties[item].type

--- a/packages/generator/src/components/RightSideBar/Check/index.tsx
+++ b/packages/generator/src/components/RightSideBar/Check/index.tsx
@@ -152,7 +152,7 @@ const CheckConfig = (): JSX.Element => {
   // 校验配置schema
   const unitedSchema = useMemo<UnitedSchema>(() => {
     return {
-      validateTime: 'change',
+      showError: 'change',
       theme: 'antd',
       ui: {
         containerStyle: {
@@ -162,15 +162,16 @@ const CheckConfig = (): JSX.Element => {
       schema: !selectedFieldKey
         ? [
             {
-              fieldKey: 'validateTime',
+              fieldKey: 'showError',
               type: 'string',
-              title: '校验时机',
-              default: 'submit',
+              title: '错误展示策略',
+              default: 'change',
               ui: {
                 type: 'select',
                 options: [
-                  { label: '值变化时', value: 'change' },
-                  { label: '提交时', value: 'submit' },
+                  { label: '实时展示', value: 'change' },
+                  { label: '提交时展示', value: 'submit' },
+                  { label: '不展示', value: 'none' },
                 ],
               },
             },
@@ -345,7 +346,7 @@ const CheckConfig = (): JSX.Element => {
     Object.entries(dataSchema).map(([key, value]) => {
       // TODO @jiangxiaowei 针对嵌套做适配
       // TODO @jiangxiaowei 支持自定义转换
-      if (['validateTime', 'requiredMode'].includes(key)) {
+      if (['validateTime', 'showError', 'requiredMode'].includes(key)) {
         setDeepProp(key.split('.'), formData, value)
       } else if (key !== 'errorMessage') {
         setDeepProp(
@@ -398,7 +399,7 @@ const CheckConfig = (): JSX.Element => {
       const data = get(changeKey).data
       if (
         !selectedFieldKey &&
-        ['validateTime', 'requiredMode'].includes(changeKey)
+        ['validateTime', 'showError', 'requiredMode'].includes(changeKey)
       ) {
         generatorContext.current?.merge('', 'dataSchema', {
           [changeKey]: data,

--- a/packages/generator/src/components/RightSideBar/EditJSON.tsx
+++ b/packages/generator/src/components/RightSideBar/EditJSON.tsx
@@ -15,7 +15,7 @@ import MonacoEdit from './MonacoEdit'
 import { OnChange } from '@monaco-editor/react'
 const defaultValue = JSON.stringify({
   theme: 'antd',
-  validateTime: 'change',
+  showError: 'change',
   schema: [],
 })
 

--- a/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
+++ b/packages/generator/src/components/RightSideBar/PropertyConfig/index.tsx
@@ -56,6 +56,7 @@ const PropertyConfig = () => {
       description: uiSchema.description || {},
       ...(type === 'root' && { footer: {} }),
       validateTime: dataSchema?.validateTime || 'change',
+      showError: dataSchema?.showError || 'change',
       ...((uiSchema?.queryConfig as QueryConfig)?.setPath == 'options'
         ? { options: (uiSchema?.queryConfig as QueryConfig)?.options || [] }
         : null),
@@ -73,6 +74,7 @@ const PropertyConfig = () => {
     themeAndType,
     dataSchema.$fieldKey,
     dataSchema?.validateTime,
+    dataSchema?.showError,
     dataSchema.default,
     fieldKey,
     uiSchema,
@@ -181,6 +183,9 @@ const PropertyConfig = () => {
       let changeSchema = 'uiSchema'
       // 处理全局属性
       if (changeKey === 'validateTime') {
+        changeSchema = 'dataSchema'
+      }
+      if (changeKey === 'showError') {
         changeSchema = 'dataSchema'
       }
       // 更改表单fieldKey
@@ -384,7 +389,7 @@ const PropertyConfig = () => {
    */
   const unitedSchema = useMemo<UnitedSchema>(() => {
     return {
-      validateTime: 'change',
+      showError: 'change',
       theme: 'antd',
       ui: {
         ...(propertyConfigOptions.control && {

--- a/packages/generator/src/store/unclassified/index.ts
+++ b/packages/generator/src/store/unclassified/index.ts
@@ -18,7 +18,7 @@ export const schemaAtom = atom<UnitedSchema>({
   key: 'unitedSchema',
   default: {
     theme: 'antd',
-    validateTime: 'change',
+    showError: 'change',
     type: 'object',
     schema: [],
   },

--- a/packages/utils/src/schemaHandle/types.ts
+++ b/packages/utils/src/schemaHandle/types.ts
@@ -130,6 +130,7 @@ export type UiSchema = {
 export type DataSchema = {
   type: string
   validateTime: 'submit' | 'change'
+  showError: 'change' | 'submit' | 'none'
   requiredMode: 'default' | 'empty'
   properties?: Map
   items?: Array<Map> | Map
@@ -147,7 +148,8 @@ export type DataSchema = {
  */
 export type UnitedSchema = {
   theme?: 'antd' | 'babel-ui' | 'drip-design' | string
-  validateTime?: string
+  validateTime?: 'change' | 'submit'
+  showError?: 'change' | 'submit' | 'none'
   requiredMode?: 'default' | 'empty'
   title?: string
   ui?: Map

--- a/website/docs/use/errorMessage 错误提示.mdx
+++ b/website/docs/use/errorMessage 错误提示.mdx
@@ -7,9 +7,13 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 
 drip-form 是实时校验的。不过可以通过配置`dataSchema`来控制是否展示错误信息
 
-`dataSchema`的`validateTime`字段为`change`时，将会展示表单错误信息在表单下方。
+`dataSchema`的`showError`字段为`change`时，将会展示表单错误信息在表单下方。
 
-不配置`validateTime`字段时，默认不展示错误信息
+`dataSchema`的`showError`字段为`submit`时，将会在提交时展示表单错误信息在表单下方，提交前不展示。
+
+`dataSchema`的`showError`字段为`none`时，将不会展示表单错误信息，可自行获取错误信息进行展示，参考文末提示。
+
+不配置`showError`字段时，默认实时展示错误信息
 
 ## 使用场景
 
@@ -19,7 +23,7 @@ drip-form 是实时校验的。不过可以通过配置`dataSchema`来控制是�
    {
    	"$schema": "http://json-schema.org/draft-07/schema#",
    	"type": "object",
-   	"validateTime": "change",
+   	"showError": "change",
    	"properties": {
    		"name": {
    			"title": "名字",
@@ -44,14 +48,12 @@ drip-form 是实时校验的。不过可以通过配置`dataSchema`来控制是�
 
 2. 表单提交才展示错误信息
 
-   1. 首先设置 dataSchem 的 validateTime 字段为`submit`
-
       ```json title="dataSchema.json"
       {
       	"$schema": "http://json-schema.org/draft-07/schema#",
       	"type": "object",
       	//highlight-next-line
-      	"validateTime": "submit",
+      	"showError": "submit",
       	"properties": {
       		"name": {
       			"title": "名字",
@@ -68,45 +70,28 @@ drip-form 是实时校验的。不过可以通过配置`dataSchema`来控制是�
       }
       ```
 
-   2. 点击提交按钮，使用`ref.current.dispatch`设置 validateTime 为 change
+3. 不展示错误信息
 
-      ```jsx
-      const Form = () => {
-      	const ref = useRef(null)
-      	const onSubmit = () => {
-      		//highlight-start
-      		const { dispatch } = ref.current
-      		// 点击的时候才展示错误信息
-      		dispatch({
-      			type: 'setValidate',
-      			action: {
-      				set: {
-      					validateTime: 'change',
-      				},
-      			},
-      		})
-      		//highlight-end
+
+      ```json title="dataSchema.json"
+      {
+      	"$schema": "http://json-schema.org/draft-07/schema#",
+      	"type": "object",
+      	//highlight-next-line
+      	"showError": "none",
+      	"properties": {
+      		"name": {
+      			"title": "名字",
+      			"type": "string",
+      			"transform": ["trim"]
+      		}
+      	},
+      	"required": ["name"],
+      	"errorMessage": {
+      		"required": {
+      			"name": "必填"
+      		}
       	}
-
-      	return (
-      		<>
-      			<DripForm
-      				ref={ref}
-      				dataSchema={dataSchemaMult}
-      				uiSchema={uiSchemaMult}
-      				uiComponents={{ 'drip-design': DripDesign }}
-      			/>
-      			<Button
-      				type="primary"
-      				className="button--submit"
-      				onClick={() => {
-      					onSubmit()
-      				}}
-      			>
-      				提交表单
-      			</Button>
-      		</>
-      	)
       }
       ```
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

当前校验时机的描述和实际效果不完全匹配，因此改为错误展示策略，另外此前校验时机仅区分值变化时和提交时，而提交时事实上不能在提交时自动展示错误，需要用户的进一步操作，因此错误展示策略设置3种策略，实时展示、提交时展示和不展示，其中实时同原值变化时，不展示同原提交时，新的提交时，会在用户点击或调用submit时，自动修改策略，展示错误信息。

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N
