### PR TITLE
fix: 选中表单控件滚动到顶部效果改为不在视口内时滚动到视口内

### DIFF
--- a/packages/generator/src/components/Viewport/index.tsx
+++ b/packages/generator/src/components/Viewport/index.tsx
@@ -182,7 +182,11 @@ const Viewport = forwardRef<HTMLDivElement, Props>(
     }, [setThemeAndType, setSelectedFieldKey])
 
     return (
-      <div className={styles.viewport} onClick={clickFn}>
+      <div
+        id="drip-form-generator--viewport"
+        className={styles.viewport}
+        onClick={clickFn}
+      >
         <TitleHeader />
         <div className={styles.formstyle} ref={ref}>
           <DripFrom


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to  here: https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

当前generator，选中控件时，控件将滚动到预览区顶部（如果可滚动），这种表现会对让用户产生误解，找不到自己选中的控件，因此改为若选中控件不位于视口，则滚动到视口中，否则不做操作

### Have you read the [Contributing Guidelines on pull requests](https://github.com/JDFED/drip-form/blob/dev/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N

## Related PRs

N
